### PR TITLE
Fix warning message for carousel view in selected story block

### DIFF
--- a/assets/src/selected-stories-block/block/edit.js
+++ b/assets/src/selected-stories-block/block/edit.js
@@ -23,8 +23,8 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, _x, sprintf } from '@wordpress/i18n';
-import { useState, RawHTML, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -75,16 +75,6 @@ const SelectedStoriesEdit = ({
 
   const label = __('Selected Web Stories', 'web-stories');
   const { config } = global.webStoriesSelectedBlockSettings;
-
-  const previewLink = wp.data.select('core/editor').getEditedPostPreviewLink();
-  const carouselMessage = sprintf(
-    '<i><b></b> %1$s <a target="__blank" href="%2$s">%3$s</a> %4$s</i>',
-    _x('Note:', 'informational message', 'web-stories'),
-    __("Carousel view's functionality will not work in Editor.", 'web-stories'),
-    previewLink,
-    __('Preview', 'web-stories'),
-    __('post to see it in action.', 'web-stories')
-  );
 
   const willShowStoryPoster = 'grid' != viewType ? true : isShowingStoryPoster;
   const willShowDate = 'circles' === viewType ? false : isShowingDate;
@@ -179,11 +169,6 @@ const SelectedStoriesEdit = ({
           </div>
           {isShowingViewAll && (
             <div className="latest-stories__archive-link">{viewAllLabel}</div>
-          )}
-          {'carousel' === viewType && (
-            <span className="latest-stories__carousel-message">
-              <RawHTML>{carouselMessage}</RawHTML>
-            </span>
           )}
         </div>
       )}

--- a/assets/src/selected-stories-block/block/selectedStoriesControls.js
+++ b/assets/src/selected-stories-block/block/selectedStoriesControls.js
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
   Button,
   ToolbarGroup,
@@ -31,8 +31,10 @@ import {
   ToggleControl,
   SVG,
   Path,
+  Notice,
 } from '@wordpress/components';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import { RawHTML } from '@wordpress/element';
 
 /* From https://material.io/tools/icons */
 const carouselIcon = (
@@ -57,9 +59,18 @@ const SelectedStoriesControls = (props) => {
     viewAllLinkLabel,
     isShowingStoryPoster,
     setAttributes,
-    // carouselSettings,
     imageOnRight,
   } = props;
+
+  const previewLink = wp.data.select('core/editor').getEditedPostPreviewLink();
+  const carouselMessage = sprintf(
+    /* Translators: Carousel informational message. 1: Preview link. */
+    __(
+      `<i><b>Note:</b> Carousel view's functionality will not work in Editor. <a target="__blank" href="%1$s">Preview</a> post to see it in action.</i>`,
+      'web-stories'
+    ),
+    previewLink
+  );
 
   const toggleView = (newViewType) => {
     if (newViewType) {
@@ -126,6 +137,15 @@ const SelectedStoriesControls = (props) => {
           className="latest-stories-settings"
           title={__('Story settings', 'web-stories')}
         >
+          {'carousel' === viewType && (
+            <Notice
+              className="latest-stories-carousel-message"
+              isDismissible={false}
+              status="warning"
+            >
+              <RawHTML>{carouselMessage}</RawHTML>
+            </Notice>
+          )}
           <ToggleControl
             className={!isViewType('grid') ? 'is-disabled' : ''}
             label={__('Show story cover images', 'web-stories')}


### PR DESCRIPTION
Removed the warning message from under the stories and show it on the sidebar instead, just like the latest stories block.