### PR TITLE
Show story cover image instead of story page in story picker modal

### DIFF
--- a/assets/src/selected-stories-block/block/selectStories.js
+++ b/assets/src/selected-stories-block/block/selectStories.js
@@ -43,7 +43,6 @@ import {
 import { getRelativeDisplayDate } from '../../date';
 import { DASHBOARD_LEFT_NAV_WIDTH } from '../../dashboard/constants/pageStructure';
 import {
-  CardPreviewContainer,
   CardTitle,
   Dropdown,
   InfiniteScroller,
@@ -54,6 +53,7 @@ import { TransformProvider } from '../../edit-story/components/transform';
 import FontProvider from '../../dashboard/app/font/fontProvider';
 import { StoryGridItem } from './components/cardGridItem';
 import ItemOverlay from './components/itemOverlay';
+import StoryPreview from './storyPreview';
 
 const StoryFilter = styled.div`
   position: sticky;
@@ -278,15 +278,7 @@ function SelectStories({
                       role="listitem"
                       data-testid={`story-grid-item-${story.id}`}
                     >
-                      <CardPreviewContainer
-                        ariaLabel={sprintf(
-                          /* translators: %s: story title. */
-                          __('preview of %s', 'web-stories'),
-                          story.title
-                        )}
-                        pageSize={pageSize}
-                        story={story}
-                      />
+                      <StoryPreview story={story} pageSize={pageSize} />
                       <DetailRow>
                         <CardTitle
                           tabIndex={-1}

--- a/assets/src/selected-stories-block/block/sortStories.js
+++ b/assets/src/selected-stories-block/block/sortStories.js
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Draggable } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -30,13 +30,13 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { PageSizePropType } from '../../dashboard/types';
-import { CardPreviewContainer } from '../../dashboard/components';
 import { UnitsProvider } from '../../edit-story/units';
 import { TransformProvider } from '../../edit-story/components/transform';
 import FontProvider from '../../dashboard/app/font/fontProvider';
 import reshapeStoryObject from '../../dashboard/app/serializers/stories';
 import { StoryGrid, StoryGridItem } from './components/cardGridItem';
 import ItemOverlay from './components/itemOverlay';
+import StoryPreview from './storyPreview';
 
 function SortStories({
   selectedStories,
@@ -141,15 +141,7 @@ function SortStories({
                             data-order={index}
                             draggable
                           >
-                            <CardPreviewContainer
-                              ariaLabel={sprintf(
-                                /* translators: %s: story title. */
-                                __('preview of %s', 'web-stories'),
-                                story.title
-                              )}
-                              pageSize={pageSize}
-                              story={story}
-                            />
+                            <StoryPreview pageSize={pageSize} story={story} />
                             <ItemOverlay
                               isSelected={true}
                               pageSize={pageSize}

--- a/assets/src/selected-stories-block/block/storyPreview.js
+++ b/assets/src/selected-stories-block/block/storyPreview.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { CardPreviewContainer } from '../../dashboard/components';
+import { StoryPropType, PageSizePropType } from '../../dashboard/types';
+
+const StoryPreviewCover = styled.div(
+  ({ coverImage, pageSize, theme }) => `
+  background-image: url(${coverImage});
+  position: relative;
+  height: ${pageSize.containerHeight}px;
+  width: 100%;
+  overflow: hidden;
+  z-index: -1;
+  background-size: cover;
+  background-position: center;
+  border-radius: ${theme.DEPRECATED_THEME.storyPreview.borderRadius}px;
+  border: ${theme.DEPRECATED_THEME.borders.gray75};
+`
+);
+
+function StoryPreview({ story, pageSize }) {
+  return story.originalStoryData.featured_media_url ? (
+    <StoryPreviewCover
+      ariaLabel={sprintf(
+        /* translators: %s: story title. */
+        __('preview of %s', 'web-stories'),
+        story.title
+      )}
+      coverImage={story.originalStoryData.featured_media_url}
+      pageSize={pageSize}
+    />
+  ) : (
+    <CardPreviewContainer
+      ariaLabel={sprintf(
+        /* translators: %s: story title. */
+        __('preview of %s', 'web-stories'),
+        story.title
+      )}
+      pageSize={pageSize}
+      story={story}
+    />
+  );
+}
+
+StoryPreview.propTypes = {
+  story: StoryPropType,
+  pageSize: PageSizePropType,
+};
+
+export default StoryPreview;


### PR DESCRIPTION
This PR will display the story cover images in story picker modal instead of the story's first page by default. If there is no cover image, then it will fallback to show the first page as we're currently showing.