### PR TITLE
Fix rearrange stories adds extra paragraph block in block editor

### DIFF
--- a/assets/src/selected-stories-block/block/sortStories.js
+++ b/assets/src/selected-stories-block/block/sortStories.js
@@ -106,6 +106,9 @@ function SortStories({
                     event.target.closest('.droppable').style.borderLeft = 0;
                   }}
                   onDrop={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+
                     // Update the list after drop
                     if (draggedElID) {
                       const oldIndex = selectedStoryList.findIndex(


### PR DESCRIPTION
There is a drag and drop issue when we try to rearrange the stories. I noticed that currently it adds an extra paragraph block in block editor every time I drag-n-drop a story. You can see the issue in this demo video https://www.loom.com/share/094eca3c098546b4919c9d68a9cba4d3

This small PR fixes this issue.