### PR TITLE
Following changes are added for the 'Web Stories' Blocks.

### DIFF
--- a/assets/src/latest-stories-block/block/block.json
+++ b/assets/src/latest-stories-block/block/block.json
@@ -38,9 +38,9 @@
       "type": "string",
       "default": ""
     },
-    "isShowingStoryPoster": {
+    "isShowingStoryPlayer": {
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "carouselSettings": {
       "type": "object",
@@ -61,6 +61,10 @@
     "align": {
       "type": "string",
       "default": "none"
+    },
+    "isStyleSquared": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/assets/src/latest-stories-block/block/edit.css
+++ b/assets/src/latest-stories-block/block/edit.css
@@ -51,7 +51,6 @@
   );
   top: 0;
   left: 0;
-  border-radius: 20px;
   z-index: 1;
 }
 
@@ -75,7 +74,6 @@
   background-position: center;
   height: 100%;
   width: 100%;
-  border-radius: 20px;
 }
 
 /* story content overlay styles */
@@ -92,7 +90,6 @@
   font-size: 12px;
   line-height: 16px;
   letter-spacing: 0.2px;
-  border-radius: 20px;
 }
 
 .wp-block-web-stories-latest-stories .story-content-overlay__author-date {
@@ -126,12 +123,7 @@
   flex-shrink: 0;
   flex-grow: 0;
   margin: 16px;
-}
-
-.wp-block-web-stories-latest-stories.is-view-type-grid
-  .latest-stories__inner-wrapper {
   border: 1px solid #8080805e;
-  border-radius: 20px;
 }
 
 .wp-block-web-stories-latest-stories.is-view-type-grid.columns-1
@@ -273,12 +265,19 @@
   margin-right: 32px;
   min-width: 250px;
   flex-shrink: 0;
+  border: 1px solid #8080805e;
 }
 
-.wp-block-web-stories-latest-stories.is-view-type-carousel
-  .latest-stories__inner-wrapper {
-  border: 1px solid #8080805e;
+/* Stories Block Styles */
+
+.wp-block-web-stories-latest-stories.is-style-default.is-view-type-grid
+  .latest-stories__controller,
+.wp-block-web-stories-latest-stories.is-style-default.is-view-type-list
+  .latest-stories__story-placeholder,
+.wp-block-web-stories-latest-stories.is-style-default.is-view-type-carousel
+  .latest-stories__story-wrapper {
   border-radius: 20px;
+  overflow: hidden;
 }
 
 /* Stories archive link styles */

--- a/assets/src/latest-stories-block/block/edit.js
+++ b/assets/src/latest-stories-block/block/edit.js
@@ -55,10 +55,11 @@ const LatestStoriesEdit = ({ attributes, setAttributes }) => {
     isShowingAuthor,
     isShowingViewAll,
     viewAllLinkLabel,
-    isShowingStoryPoster,
+    isShowingStoryPlayer,
     carouselSettings,
     authors,
     imageOnRight,
+    isStyleSquared,
   } = attributes;
 
   const [fetchedStories, setFetchedStories] = useState([]);
@@ -144,7 +145,27 @@ const LatestStoriesEdit = ({ attributes, setAttributes }) => {
     debouncedFetchLatestStories();
   }, [numOfStories]); /* eslint-disable-line react-hooks/exhaustive-deps */
 
-  const willShowStoryPoster = 'grid' != viewType ? true : isShowingStoryPoster;
+  useEffect(() => {
+    if ('circles' !== viewType) {
+      setAttributes({
+        isShowingStoryPlayer: false,
+        isShowingTitle: true,
+        isShowingAuthor: true,
+        isShowingDate: true,
+      });
+    }
+
+    if ('circles' === viewType) {
+      setAttributes({
+        isShowingStoryPlayer: false,
+        isShowingTitle: true,
+      });
+    }
+  }, [viewType, setAttributes]);
+
+  const willShowStoryPlayer =
+    'grid' !== viewType ? false : isShowingStoryPlayer;
+
   const willShowDate = 'circles' === viewType ? false : isShowingDate;
   const willShowAuthor = 'circles' === viewType ? false : isShowingAuthor;
   const viewAllLabel = viewAllLinkLabel
@@ -158,6 +179,10 @@ const LatestStoriesEdit = ({ attributes, setAttributes }) => {
 
   const alignmentClass = classNames({ [`align${align}`]: align });
   const blockClasses = classNames(
+    {
+      'is-style-default': !isStyleSquared && !isShowingStoryPlayer,
+      'is-style-squared': isStyleSquared,
+    },
     'wp-block-web-stories-latest-stories latest-stories',
     { [`is-view-type-${viewType}`]: viewType },
     { [`columns-${numOfColumns}`]: 'grid' === viewType && numOfColumns }
@@ -175,10 +200,11 @@ const LatestStoriesEdit = ({ attributes, setAttributes }) => {
         isShowingAuthor={isShowingAuthor}
         isShowingViewAll={isShowingViewAll}
         viewAllLinkLabel={viewAllLinkLabel}
-        isShowingStoryPoster={isShowingStoryPoster}
+        isShowingStoryPlayer={isShowingStoryPlayer}
         carouselSettings={carouselSettings}
         authors={authors}
         imageOnRight={imageOnRight}
+        isStyleSquared={isStyleSquared}
         setAttributes={setAttributes}
       />
 
@@ -208,7 +234,7 @@ const LatestStoriesEdit = ({ attributes, setAttributes }) => {
                   date={story.date_gmt}
                   author={author ? author.name : ''}
                   poster={story.featured_media_url}
-                  isShowingStoryPoster={willShowStoryPoster}
+                  isShowingStoryPlayer={willShowStoryPlayer}
                   imageOnRight={imageOnRight}
                   isShowingAuthor={willShowAuthor}
                   isShowingDate={willShowDate}
@@ -238,10 +264,11 @@ LatestStoriesEdit.propTypes = {
     isShowingAuthor: PropTypes.bool,
     isShowingViewAll: PropTypes.bool,
     viewAllLinkLabel: PropTypes.bool,
-    isShowingStoryPoster: PropTypes.bool,
+    isShowingStoryPlayer: PropTypes.bool,
     carouselSettings: PropTypes.object,
     authors: PropTypes.array,
     imageOnRight: PropTypes.bool,
+    isStyleSquared: PropTypes.bool,
   }),
   setAttributes: PropTypes.func.isRequired,
 };

--- a/assets/src/latest-stories-block/block/index.js
+++ b/assets/src/latest-stories-block/block/index.js
@@ -47,10 +47,13 @@ const settings = {
   example: {
     // TODO: Replace with something custom.
     attributes: {
-      url:
-        'https://preview.amp.dev/documentation/examples/introduction/stories_in_amp',
+      viewType: 'grid',
       title: __('Stories in AMP', 'web-stories'),
-      poster: 'https://amp.dev/static/samples/img/story_dog2_portrait.jpg',
+      numOfStories: 1,
+      numOfColumns: 2,
+      isShowingTitle: true,
+      isShowingAuthor: true,
+      isShowingStoryPlayer: false,
     },
   },
   supports: {

--- a/assets/src/latest-stories-block/block/latestStoriesControls.js
+++ b/assets/src/latest-stories-block/block/latestStoriesControls.js
@@ -67,10 +67,11 @@ const LatestStoriesControls = (props) => {
     isShowingAuthor,
     isShowingViewAll,
     viewAllLinkLabel,
-    isShowingStoryPoster,
+    isShowingStoryPlayer,
     setAttributes,
     authors,
     imageOnRight,
+    isStyleSquared,
   } = props;
 
   const orderByOptions = [
@@ -173,11 +174,11 @@ const LatestStoriesControls = (props) => {
           )}
           <ToggleControl
             className={!isViewType('grid') ? 'is-disabled' : ''}
-            label={__('Show story cover images', 'web-stories')}
-            checked={!isViewType('grid') ? true : isShowingStoryPoster}
+            label={__('Replace cover image with story player', 'web-stories')}
+            checked={!isViewType('grid') ? false : isShowingStoryPlayer}
             onChange={() => {
               if (isViewType('grid')) {
-                setAttributes({ isShowingStoryPoster: !isShowingStoryPoster });
+                setAttributes({ isShowingStoryPlayer: !isShowingStoryPlayer });
               }
             }}
           />
@@ -212,6 +213,15 @@ const LatestStoriesControls = (props) => {
               checked={imageOnRight}
               onChange={() => {
                 setAttributes({ imageOnRight: !imageOnRight });
+              }}
+            />
+          )}
+          {!isViewType('circles') && !isShowingStoryPlayer && (
+            <ToggleControl
+              label={__('Show square corners', 'web-stories')}
+              checked={isStyleSquared}
+              onChange={() => {
+                setAttributes({ isStyleSquared: !isStyleSquared });
               }}
             />
           )}
@@ -279,10 +289,11 @@ LatestStoriesControls.propTypes = {
   isShowingAuthor: PropTypes.bool,
   isShowingViewAll: PropTypes.bool,
   viewAllLinkLabel: PropTypes.string,
-  isShowingStoryPoster: PropTypes.bool,
+  isShowingStoryPlayer: PropTypes.bool,
   setAttributes: PropTypes.func.isRequired,
   authors: PropTypes.array,
   imageOnRight: PropTypes.bool,
+  isStyleSquared: PropTypes.bool,
 };
 
 export default LatestStoriesControls;

--- a/assets/src/latest-stories-block/block/storyPlayer.js
+++ b/assets/src/latest-stories-block/block/storyPlayer.js
@@ -32,14 +32,14 @@ function StoryPlayer({
   poster,
   author,
   date,
-  isShowingStoryPoster,
+  isShowingStoryPlayer,
   isShowingAuthor,
   isShowingDate,
   isShowingTitle,
   imageOnRight,
 }) {
   const singleStoryClasses = classNames('latest-stories__story-wrapper', {
-    'has-poster': isShowingStoryPoster,
+    'has-poster': !isShowingStoryPlayer,
   });
   const imageAlignmentClass = classNames('latest-stories__inner-wrapper', {
     [`image-align-right`]: imageOnRight,
@@ -50,7 +50,7 @@ function StoryPlayer({
   const ref = useRef();
 
   useEffect(() => {
-    if (isShowingStoryPoster) {
+    if (!isShowingStoryPlayer) {
       return;
     }
 
@@ -58,13 +58,13 @@ function StoryPlayer({
       const player = new global.AmpStoryPlayer(global, ref.current);
       player.load();
     }
-  }, [isShowingStoryPoster]);
+  }, [isShowingStoryPlayer]);
 
   return (
     <div className="latest-stories__controller">
       <div className={singleStoryClasses}>
         <div className={imageAlignmentClass}>
-          {isShowingStoryPoster ? (
+          {!isShowingStoryPlayer ? (
             <div
               className="latest-stories__story-placeholder"
               style={{ backgroundImage: `url(${poster}` }}
@@ -117,7 +117,7 @@ StoryPlayer.propTypes = {
   poster: PropTypes.string,
   author: PropTypes.string,
   date: PropTypes.string,
-  isShowingStoryPoster: PropTypes.bool,
+  isShowingStoryPlayer: PropTypes.bool,
   isShowingAuthor: PropTypes.bool,
   isShowingDate: PropTypes.bool,
   isShowingTitle: PropTypes.bool,

--- a/assets/src/selected-stories-block/block/block.json
+++ b/assets/src/selected-stories-block/block/block.json
@@ -34,9 +34,9 @@
       "type": "string",
       "default": ""
     },
-    "isShowingStoryPoster": {
+    "isShowingStoryPlayer": {
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "carouselSettings": {
       "type": "object",
@@ -53,6 +53,10 @@
     "align": {
       "type": "string",
       "default": "none"
+    },
+    "isStyleSquared": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/assets/src/selected-stories-block/block/selectedStoriesControls.js
+++ b/assets/src/selected-stories-block/block/selectedStoriesControls.js
@@ -57,9 +57,10 @@ const SelectedStoriesControls = (props) => {
     isShowingAuthor,
     isShowingViewAll,
     viewAllLinkLabel,
-    isShowingStoryPoster,
+    isShowingStoryPlayer,
     setAttributes,
     imageOnRight,
+    isStyleSquared,
   } = props;
 
   const previewLink = wp.data.select('core/editor').getEditedPostPreviewLink();
@@ -148,11 +149,11 @@ const SelectedStoriesControls = (props) => {
           )}
           <ToggleControl
             className={!isViewType('grid') ? 'is-disabled' : ''}
-            label={__('Show story cover images', 'web-stories')}
-            checked={!isViewType('grid') ? true : isShowingStoryPoster}
+            label={__('Replace cover image with story player', 'web-stories')}
+            checked={!isViewType('grid') ? false : isShowingStoryPlayer}
             onChange={() => {
               if (isViewType('grid')) {
-                setAttributes({ isShowingStoryPoster: !isShowingStoryPoster });
+                setAttributes({ isShowingStoryPlayer: !isShowingStoryPlayer });
               }
             }}
           />
@@ -190,6 +191,15 @@ const SelectedStoriesControls = (props) => {
               }}
             />
           )}
+          {!isViewType('circles') && !isShowingStoryPlayer && (
+            <ToggleControl
+              label={__('Show square corners', 'web-stories')}
+              checked={isStyleSquared}
+              onChange={() => {
+                setAttributes({ isStyleSquared: !isStyleSquared });
+              }}
+            />
+          )}
           <ToggleControl
             label={__("Show 'View All Stories' link", 'web-stories')}
             checked={isShowingViewAll}
@@ -220,10 +230,11 @@ SelectedStoriesControls.propTypes = {
   isShowingAuthor: PropTypes.bool,
   isShowingViewAll: PropTypes.bool,
   viewAllLinkLabel: PropTypes.string,
-  isShowingStoryPoster: PropTypes.bool,
+  isShowingStoryPlayer: PropTypes.bool,
   setAttributes: PropTypes.func.isRequired,
   // carouselSettings: PropTypes.object,
   imageOnRight: PropTypes.bool,
+  isStyleSquared: PropTypes.bool,
 };
 
 export default SelectedStoriesControls;

--- a/includes/Block/Latest_Stories_Block.php
+++ b/includes/Block/Latest_Stories_Block.php
@@ -134,9 +134,9 @@ class Latest_Stories_Block extends Embed_Base {
 						'type'    => 'string',
 						'default' => '',
 					],
-					'isShowingStoryPoster' => [
+					'isShowingStoryPlayer' => [
 						'type'    => 'boolean',
-						'default' => true,
+						'default' => false,
 					],
 					'carouselSettings'     => [
 						'type'    => 'object',
@@ -151,6 +151,10 @@ class Latest_Stories_Block extends Embed_Base {
 						'default' => [],
 					],
 					'imageOnRight'         => [
+						'type'    => 'boolean',
+						'default' => false,
+					],
+					'isStyleSquared'       => [
 						'type'    => 'boolean',
 						'default' => false,
 					],
@@ -209,10 +213,9 @@ class Latest_Stories_Block extends Embed_Base {
 		}
 
 		$content              = '';
-		$block_classes        = 'web-stories web-stories';
-		$single_story_classes = ( ! empty( $attributes['isShowingStoryPoster'] ) && true === $attributes['isShowingStoryPoster'] ) ?
-			'web-stories__story-wrapper has-poster' :
-			'web-stories__story-wrapper';
+		$block_classes        = 'web-stories ';
+		$block_classes        = ( ! empty( $attributes['isStyleSquared'] ) || ! empty( $attributes['isShowingStoryPlayer'] ) ) ? $block_classes . 'is-style-squared ' : $block_classes . 'is-style-default ';
+		$single_story_classes = ( empty( $attributes['isShowingStoryPlayer'] ) ) ? 'web-stories__story-wrapper has-poster ' : 'web-stories__story-wrapper ';
 		$block_style          = '';
 
 		$block_classes  .= ( ! empty( $attributes['viewType'] ) ) ? " is-view-type-{$attributes['viewType']}" : ' is-view-type-grid';
@@ -268,7 +271,7 @@ class Latest_Stories_Block extends Embed_Base {
 						$current_post_id = get_the_ID();
 						$story_attrs     = $this->get_story_attrs( $current_post_id, $single_story_classes );
 
-						if ( ( ! $is_grid_view ) || ( ! empty( $attributes['isShowingStoryPoster'] && true === $attributes['isShowingStoryPoster'] ) ) ) :
+						if ( ( ! $is_grid_view ) || ( empty( $attributes['isShowingStoryPlayer'] ) ) ) :
 							if (
 								( function_exists( 'amp_is_request' ) && ! amp_is_request() ) ||
 								( function_exists( 'is_amp_endpoint' ) && ! is_amp_endpoint() )

--- a/includes/Block/Selected_Stories_Block.php
+++ b/includes/Block/Selected_Stories_Block.php
@@ -123,9 +123,9 @@ class Selected_Stories_Block extends Latest_Stories_Block {
 						'type'    => 'string',
 						'default' => '',
 					],
-					'isShowingStoryPoster' => [
+					'isShowingStoryPlayer' => [
 						'type'    => 'boolean',
-						'default' => true,
+						'default' => false,
 					],
 					'carouselSettings'     => [
 						'type'    => 'object',
@@ -136,6 +136,10 @@ class Selected_Stories_Block extends Latest_Stories_Block {
 						],
 					],
 					'imageOnRight'         => [
+						'type'    => 'boolean',
+						'default' => false,
+					],
+					'isStyleSquared'       => [
 						'type'    => 'boolean',
 						'default' => false,
 					],

--- a/includes/assets/latest-stories.css
+++ b/includes/assets/latest-stories.css
@@ -36,7 +36,6 @@
   );
   top: 0;
   left: 0;
-  border-radius: 20px;
   z-index: 1;
 }
 
@@ -58,7 +57,6 @@
   background-position: center;
   height: 100%;
   width: 100%;
-  border-radius: 20px;
 }
 
 /* story content overlay styles */
@@ -75,7 +73,6 @@
   font-size: 12px;
   line-height: 16px;
   letter-spacing: 0.2px;
-  border-radius: 20px;
 }
 
 .web-stories .story-content-overlay__author-date {
@@ -106,11 +103,6 @@
 .web-stories.is-view-type-grid .web-stories__controller {
   flex-basis: calc(100% - 32px);
   margin: 16px;
-}
-
-.web-stories.is-view-type-grid .web-stories__inner-wrapper {
-  border: 1px solid #8080805e;
-  border-radius: 20px;
 }
 
 @media only screen and (min-width: 600px) {
@@ -240,12 +232,21 @@
 
 .web-stories.is-view-type-carousel .web-stories__inner-wrapper {
   border: 1px solid #8080805e;
-  border-radius: 20px;
 }
 
 /* Stories archive link styles */
 .web-stories__archive-link {
   margin-top: 16px;
+}
+
+/* Stories Block Styles */
+.web-stories.is-style-default.is-view-type-grid .web-stories__story-wrapper,
+.web-stories.is-style-default.is-view-type-list .web-stories__story-placeholder,
+.web-stories.is-style-default.is-view-type-carousel
+  .web-stories__story-wrapper {
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid #8080805e;
 }
 
 /* Lightbox styles */


### PR DESCRIPTION
- Web story cards default to rounded corners.
- Adds Block Control to use square corners for the web story cards.
- Defines default state ( controls ) for the views and updates the state when user switches from one view to another.

- Updates 'Latest Web Stories' Block with the following changes.
-- Replaces 'Show Story Cover Image' with the option to show story player instead.

- Updates 'Selected Web Stories' block
- Adds control for making stories with round corners.
- Replaces 'Cover Image' toggle control with 'Show Story Player' to embed stories instead.
