### PR TITLE
Web Stories customizer settings

### DIFF
--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -580,7 +580,7 @@ class Customizer {
 
 		$story_arguments['class'] = 'web-stories-list--customizer';
 
-		$stories = new Stories( $story_arguments, $query_arguments );
+		$stories = new Story_Query( $story_arguments, $query_arguments );
 
 		return $stories->render();
 

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -528,7 +528,7 @@ class Customizer {
 	/**
 	 * Renders web stories based on the customizer selected options.
 	 *
-	 * @return string|null
+	 * @return string|void
 	 */
 	public static function render_stories() {
 		$options = get_option( 'story-options' );

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -518,7 +518,7 @@ class Customizer {
 		$theme_support = wp_parse_args( $theme_support, $default_theme_support );
 
 		$theme_support['view-type']            = is_array( $theme_support['view-type'] ) ? $theme_support['view-type'] : [];
-		$theme_support['order']                = is_array( $theme_support['order'] ) ? $theme_support['order'] : [];
+		$theme_support['order']                = is_array( $theme_support['order'] ) ? array_keys( $theme_support['order'] ) : [];
 		$theme_support['number-of-stories']    = is_numeric( $theme_support['number-of-stories'] ) ? $theme_support['number-of-stories'] : 5;
 		$theme_support['grid-columns-default'] = is_numeric( $theme_support['grid-columns-default'] ) ? $theme_support['grid-columns-default'] : 2;
 

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -73,31 +73,32 @@ class Customizer {
 
 		$this->wp_customize = $wp_customize;
 
-		$options = get_theme_support( 'web-story-options' );
+		$theme_support = get_theme_support( 'web-story-options' );
+		$theme_support = ! empty( $theme_support[0] ) && is_array( $theme_support[0] ) ? $theme_support[0] : [];
 
-		$view_type         = ( ! empty( $options[0]['view-type'] ) && is_array( $options[0]['view-type'] ) ) ? $options[0]['view-type'] : [];
-		$view_type_default = ( ! empty( $options[0]['view-type-default'] ) ) ? $options[0]['view-type-default'] : 'circles';
+		$view_type         = ( ! empty( $theme_support['view-type'] ) && is_array( $theme_support['view-type'] ) ) ? $theme_support['view-type'] : [];
+		$view_type_default = ( ! empty( $theme_support['view-type-default'] ) ) ? $theme_support['view-type-default'] : 'circles';
 
-		$show_title         = ( ! empty( $options[0]['title'] ) ) ? $options[0]['title'] : false;
-		$show_title_default = ( ! empty( $options[0]['title-default'] ) ) ? $options[0]['title-default'] : false;
+		$show_title         = ( ! empty( $theme_support['title'] ) ) ? $theme_support['title'] : false;
+		$show_title_default = ( ! empty( $theme_support['title-default'] ) ) ? $theme_support['title-default'] : false;
 
-		$show_author         = ( ! empty( $options[0]['author'] ) ) ? $options[0]['author'] : false;
-		$show_author_default = ( ! empty( $options[0]['author-default'] ) ) ? $options[0]['author-default'] : false;
+		$show_author         = ( ! empty( $theme_support['author'] ) ) ? $theme_support['author'] : false;
+		$show_author_default = ( ! empty( $theme_support['author-default'] ) ) ? $theme_support['author-default'] : false;
 
-		$show_date         = ( ! empty( $options[0]['date'] ) ) ? $options[0]['date'] : false;
-		$show_date_default = ( ! empty( $options[0]['date-default'] ) ) ? $options[0]['date-default'] : false;
+		$show_date         = ( ! empty( $theme_support['date'] ) ) ? $theme_support['date'] : false;
+		$show_date_default = ( ! empty( $theme_support['date-default'] ) ) ? $theme_support['date-default'] : false;
 
-		$show_stories_archive_link = ( ! empty( $options[0]['stories-archive-link'] ) ) ? $options[0]['stories-archive-link'] : false;
-		$stories_archive_label     = ( ! empty( $options[0]['stories-archive-label'] ) ) ? $options[0]['stories-archive-label'] : 'View all stories';
+		$show_stories_archive_link = ( ! empty( $theme_support['stories-archive-link'] ) ) ? $theme_support['stories-archive-link'] : false;
+		$stories_archive_label     = ( ! empty( $theme_support['stories-archive-label'] ) ) ? $theme_support['stories-archive-label'] : 'View all stories';
 
-		$number_of_stories = ( ! empty( $options[0]['number-of-stories'] ) && is_numeric( $options[0]['number-of-stories'] ) ) ? $options[0]['number-of-stories'] : 5;
+		$number_of_stories = ( ! empty( $theme_support['number-of-stories'] ) && is_numeric( $theme_support['number-of-stories'] ) ) ? $theme_support['number-of-stories'] : 5;
 
-		$order         = ( ! empty( $options[0]['order'] ) && is_array( $options[0]['order'] ) ) ? $options[0]['order'] : [];
-		$order_default = ( ! empty( $options[0]['order-default'] ) ) ? $options[0]['order-default'] : 'latest';
+		$order         = ( ! empty( $theme_support['order'] ) && is_array( $theme_support['order'] ) ) ? $theme_support['order'] : [];
+		$order_default = ( ! empty( $theme_support['order-default'] ) ) ? $theme_support['order-default'] : 'latest';
 
-		$show_story_poster_default = ( ! empty( $options[0]['show-story-poster-default'] ) ) ? $options[0]['show-story-poster-default'] : true;
+		$show_story_poster_default = ( ! empty( $theme_support['show-story-poster-default'] ) ) ? $theme_support['show-story-poster-default'] : true;
 
-		$number_of_columns_default = ( ! empty( $options[0]['grid-columns-default'] ) && is_numeric( $options[0]['grid-columns-default'] ) ) ? $options[0]['grid-columns-default'] : 2;
+		$number_of_columns_default = ( ! empty( $theme_support['grid-columns-default'] ) && is_numeric( $theme_support['grid-columns-default'] ) ) ? $theme_support['grid-columns-default'] : 2;
 
 		// Add Content section.
 		$wp_customize->add_section(
@@ -547,24 +548,25 @@ class Customizer {
 		}
 
 		$theme_support = get_theme_support( 'web-story-options' );
+		$theme_support = ! empty( $theme_support[0] ) && is_array( $theme_support[0] ) ? $theme_support[0] : [];
 
 		$default_array = [
-			'view_type'             => ( ! empty( $theme_support[0]['view-type-default'] ) ) ? $theme_support[0]['view-type-default'] : 'circles',
-			'show_title'            => ( ! empty( $theme_support[0]['title-default'] ) ) ? $theme_support[0]['title-default'] : false,
-			'show_author'           => ( ! empty( $theme_support[0]['author-default'] ) ) ? $theme_support[0]['author-default'] : false,
-			'show_date'             => ( ! empty( $theme_support[0]['date-default'] ) ) ? $theme_support[0]['date-default'] : false,
-			'stories_archive_label' => ( ! empty( $theme_support[0]['stories-archive-label'] ) ) ? $theme_support[0]['stories-archive-label'] : 'View all stories',
-			'show_story_poster'     => ( ! empty( $theme_support[0]['show-story-poster-default'] ) ) ? $theme_support[0]['show-story-poster-default'] : true,
-			'number_of_columns'     => ( ! empty( $theme_support[0]['grid-columns-default'] ) && is_numeric( $theme_support[0]['grid-columns-default'] ) ) ? $theme_support[0]['grid-columns-default'] : 2,
+			'view_type'             => ( ! empty( $theme_support['view-type-default'] ) ) ? $theme_support['view-type-default'] : 'circles',
+			'show_title'            => ( ! empty( $theme_support['title-default'] ) ) ? $theme_support['title-default'] : false,
+			'show_author'           => ( ! empty( $theme_support['author-default'] ) ) ? $theme_support['author-default'] : false,
+			'show_date'             => ( ! empty( $theme_support['date-default'] ) ) ? $theme_support['date-default'] : false,
+			'stories_archive_label' => ( ! empty( $theme_support['stories-archive-label'] ) ) ? $theme_support['stories-archive-label'] : __( 'View all stories', 'web-stories' ),
+			'show_story_poster'     => ( ! empty( $theme_support['show-story-poster-default'] ) ) ? $theme_support['show-story-poster-default'] : true,
+			'number_of_columns'     => ( ! empty( $theme_support['grid-columns-default'] ) && is_numeric( $theme_support['grid-columns-default'] ) ) ? $theme_support['grid-columns-default'] : 2,
 		];
 
 		$query_arguments = [
-			'posts_per_page' => ( ! empty( $theme_support[0]['number-of-stories'] ) && is_numeric( $theme_support[0]['number-of-stories'] ) ) ? $theme_support[0]['number-of-stories'] : 5,
+			'posts_per_page' => ( ! empty( $theme_support['number-of-stories'] ) && is_numeric( $theme_support['number-of-stories'] ) ) ? $theme_support['number-of-stories'] : 5,
 		];
 
 		$query_arguments['posts_per_page'] = ! empty( $options['number_of_stories'] ) ? $options['number_of_stories'] : $query_arguments['posts_per_page'];
 
-		$order_by = ! empty( $theme_support[0]['order-default'] ) ? $theme_support[0]['order-default'] : 'latest';
+		$order_by = ! empty( $theme_support['order-default'] ) ? $theme_support['order-default'] : 'latest';
 		$order_by = ! empty( $options['order'] ) ? $options['order'] : $order_by;
 
 		switch ( $order_by ) {

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -73,32 +73,7 @@ class Customizer {
 
 		$this->wp_customize = $wp_customize;
 
-		$theme_support = get_theme_support( 'web-story-options' );
-		$theme_support = ! empty( $theme_support[0] ) && is_array( $theme_support[0] ) ? $theme_support[0] : [];
-
-		$view_type         = ( ! empty( $theme_support['view-type'] ) && is_array( $theme_support['view-type'] ) ) ? $theme_support['view-type'] : [];
-		$view_type_default = ( ! empty( $theme_support['view-type-default'] ) ) ? $theme_support['view-type-default'] : 'circles';
-
-		$show_title         = ( ! empty( $theme_support['title'] ) ) ? $theme_support['title'] : false;
-		$show_title_default = ( ! empty( $theme_support['title-default'] ) ) ? $theme_support['title-default'] : false;
-
-		$show_author         = ( ! empty( $theme_support['author'] ) ) ? $theme_support['author'] : false;
-		$show_author_default = ( ! empty( $theme_support['author-default'] ) ) ? $theme_support['author-default'] : false;
-
-		$show_date         = ( ! empty( $theme_support['date'] ) ) ? $theme_support['date'] : false;
-		$show_date_default = ( ! empty( $theme_support['date-default'] ) ) ? $theme_support['date-default'] : false;
-
-		$show_stories_archive_link = ( ! empty( $theme_support['stories-archive-link'] ) ) ? $theme_support['stories-archive-link'] : false;
-		$stories_archive_label     = ( ! empty( $theme_support['stories-archive-label'] ) ) ? $theme_support['stories-archive-label'] : 'View all stories';
-
-		$number_of_stories = ( ! empty( $theme_support['number-of-stories'] ) && is_numeric( $theme_support['number-of-stories'] ) ) ? $theme_support['number-of-stories'] : 5;
-
-		$order         = ( ! empty( $theme_support['order'] ) && is_array( $theme_support['order'] ) ) ? $theme_support['order'] : [];
-		$order_default = ( ! empty( $theme_support['order-default'] ) ) ? $theme_support['order-default'] : 'latest';
-
-		$show_story_poster_default = ( ! empty( $theme_support['show-story-poster-default'] ) ) ? $theme_support['show-story-poster-default'] : true;
-
-		$number_of_columns_default = ( ! empty( $theme_support['grid-columns-default'] ) && is_numeric( $theme_support['grid-columns-default'] ) ) ? $theme_support['grid-columns-default'] : 2;
+		$theme_support = self::get_stories_theme_support();
 
 		// Add Content section.
 		$wp_customize->add_section(
@@ -129,7 +104,7 @@ class Customizer {
 		$wp_customize->add_setting(
 			'story-options[view_type]',
 			[
-				'default' => $view_type_default,
+				'default' => $theme_support['view-type-default'],
 				'type'    => 'option',
 			]
 		);
@@ -140,7 +115,7 @@ class Customizer {
 				'section'         => self::SECTION_SLUG,
 				'label'           => __( 'Story view type', 'web-stories' ),
 				'type'            => 'select',
-				'choices'         => $this->get_view_type_choices( $view_type ),
+				'choices'         => $this->get_view_type_choices( $theme_support['view-type'] ),
 				'active_callback' => function() {
 					return $this->is_option_enabled( 'show_stories' );
 				},
@@ -150,7 +125,7 @@ class Customizer {
 		$wp_customize->add_setting(
 			'story-options[number_of_stories]',
 			[
-				'default'           => $number_of_stories,
+				'default'           => $theme_support['number-of-stories'],
 				'type'              => 'option',
 				'validate_callback' => [ $this, 'validate_number_of_stories' ],
 			]
@@ -175,7 +150,7 @@ class Customizer {
 		$wp_customize->add_setting(
 			'story-options[number_of_columns]',
 			[
-				'default'           => $number_of_columns_default,
+				'default'           => $theme_support['grid-columns-default'],
 				'type'              => 'option',
 				'validate_callback' => [ $this, 'validate_number_of_columns' ],
 			]
@@ -200,7 +175,7 @@ class Customizer {
 		$wp_customize->add_setting(
 			'story-options[order]',
 			[
-				'default' => $order_default,
+				'default' => $theme_support['order-default'],
 				'type'    => 'option',
 			]
 		);
@@ -211,7 +186,7 @@ class Customizer {
 				'section'         => self::SECTION_SLUG,
 				'label'           => __( 'Order by', 'web-stories' ),
 				'type'            => 'select',
-				'choices'         => $this->get_order_choices( $order ),
+				'choices'         => $this->get_order_choices( $theme_support['order'] ),
 				'active_callback' => function() {
 					return $this->is_option_enabled( 'show_stories' );
 				},
@@ -242,12 +217,12 @@ class Customizer {
 			]
 		);
 
-		if ( true === $show_title ) {
+		if ( true === $theme_support['title'] ) {
 
 			$wp_customize->add_setting(
 				'story-options[show_title]',
 				[
-					'default' => $show_title_default,
+					'default' => $theme_support['title-default'],
 					'type'    => 'option',
 				]
 			);
@@ -265,11 +240,11 @@ class Customizer {
 			);
 		}
 
-		if ( true === $show_author ) {
+		if ( true === $theme_support['author'] ) {
 			$wp_customize->add_setting(
 				'story-options[show_author]',
 				[
-					'default' => $show_author_default,
+					'default' => $theme_support['author-default'],
 					'type'    => 'option',
 				]
 			);
@@ -287,11 +262,11 @@ class Customizer {
 			);
 		}
 
-		if ( true === $show_date ) {
+		if ( true === $theme_support['date'] ) {
 			$wp_customize->add_setting(
 				'story-options[show_date]',
 				[
-					'default' => $show_date_default,
+					'default' => $theme_support['date-default'],
 					'type'    => 'option',
 				]
 			);
@@ -329,7 +304,7 @@ class Customizer {
 			]
 		);
 
-		if ( true === $show_stories_archive_link ) {
+		if ( true === $theme_support['stories-archive-link'] ) {
 			$wp_customize->add_setting(
 				'story-options[show_stories_archive_link]',
 				[
@@ -354,7 +329,7 @@ class Customizer {
 				'story-options[stories_archive_label]',
 				[
 					'type'    => 'option',
-					'default' => $stories_archive_label,
+					'default' => $theme_support['stories-archive-label'],
 				]
 			);
 
@@ -373,7 +348,7 @@ class Customizer {
 			$wp_customize->add_setting(
 				'story-options[show_story_poster]',
 				[
-					'default' => $show_story_poster_default,
+					'default' => $theme_support['show-story-poster-default'],
 					'type'    => 'option',
 				]
 			);
@@ -401,7 +376,7 @@ class Customizer {
 	 *
 	 * @return array An array of view type choices.
 	 */
-	protected function get_view_type_choices( $view_type ) {
+	private function get_view_type_choices( $view_type ) {
 
 		if ( empty( $view_type ) ) {
 			return [ 'circles' => __( 'Circles', 'web-stories' ) ];
@@ -437,7 +412,7 @@ class Customizer {
 	 *
 	 * @return array An array of order choices.
 	 */
-	protected function get_order_choices( $order ) {
+	private function get_order_choices( $order ) {
 
 		$order_choices = [];
 
@@ -477,7 +452,7 @@ class Customizer {
 	 *
 	 * @return boolean Returns true if the given option is enabled otherwise false.
 	 */
-	protected function is_option_enabled( $option_name ) {
+	private function is_option_enabled( $option_name ) {
 		$setting = $this->wp_customize->get_setting( "story-options[{$option_name}]" );
 		return ( $setting instanceof \WP_Customize_Setting && true === $setting->value() );
 	}
@@ -489,7 +464,7 @@ class Customizer {
 	 *
 	 * @return bool Whether or not current view type matches the one passed.
 	 */
-	protected function is_view_type( $view_type ) {
+	private function is_view_type( $view_type ) {
 		$setting = $this->wp_customize->get_setting( 'story-options[view_type]' );
 		return ( $setting instanceof \WP_Customize_Setting && $view_type === $setting->value() );
 	}
@@ -533,6 +508,44 @@ class Customizer {
 	}
 
 	/**
+	 * Gets the stories theme support data.
+	 *
+	 * @return array An array of web story theme support data.
+	 */
+	public static function get_stories_theme_support() {
+
+		$theme_support = get_theme_support( 'web-story-options' );
+		$theme_support = ! empty( $theme_support[0] ) && is_array( $theme_support[0] ) ? $theme_support[0] : [];
+
+		$default_theme_support = [
+			'view-type'                 => [],
+			'view-type-default'         => 'circles',
+			'grid-columns-default'      => 2,
+			'title'                     => false,
+			'title-default'             => false,
+			'author'                    => false,
+			'author-default'            => false,
+			'date'                      => false,
+			'date-default'              => false,
+			'stories-archive-link'      => true,
+			'stories-archive-label'     => __( 'View all stories', 'web-stories' ),
+			'number-of-stories'         => 5,
+			'order'                     => [],
+			'order-default'             => 'oldest',
+			'show-story-poster-default' => true,
+		];
+
+		$theme_support = wp_parse_args( $theme_support, $default_theme_support );
+
+		$theme_support['view-type']            = is_array( $theme_support['view-type'] ) ? $theme_support['view-type'] : [];
+		$theme_support['order']                = is_array( $theme_support['order'] ) ? $theme_support['order'] : [];
+		$theme_support['number-of-stories']    = is_numeric( $theme_support['number-of-stories'] ) ? $theme_support['number-of-stories'] : 5;
+		$theme_support['grid-columns-default'] = is_numeric( $theme_support['grid-columns-default'] ) ? $theme_support['grid-columns-default'] : 2;
+
+		return $theme_support;
+	}
+
+	/**
 	 * Renders web stories based on the customizer selected options.
 	 *
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
@@ -547,27 +560,23 @@ class Customizer {
 			return;
 		}
 
-		$theme_support = get_theme_support( 'web-story-options' );
-		$theme_support = ! empty( $theme_support[0] ) && is_array( $theme_support[0] ) ? $theme_support[0] : [];
+		$theme_support = self::get_stories_theme_support();
 
 		$default_array = [
-			'view_type'             => ( ! empty( $theme_support['view-type-default'] ) ) ? $theme_support['view-type-default'] : 'circles',
-			'show_title'            => ( ! empty( $theme_support['title-default'] ) ) ? $theme_support['title-default'] : false,
-			'show_author'           => ( ! empty( $theme_support['author-default'] ) ) ? $theme_support['author-default'] : false,
-			'show_date'             => ( ! empty( $theme_support['date-default'] ) ) ? $theme_support['date-default'] : false,
-			'stories_archive_label' => ( ! empty( $theme_support['stories-archive-label'] ) ) ? $theme_support['stories-archive-label'] : __( 'View all stories', 'web-stories' ),
-			'show_story_poster'     => ( ! empty( $theme_support['show-story-poster-default'] ) ) ? $theme_support['show-story-poster-default'] : true,
-			'number_of_columns'     => ( ! empty( $theme_support['grid-columns-default'] ) && is_numeric( $theme_support['grid-columns-default'] ) ) ? $theme_support['grid-columns-default'] : 2,
+			'view_type'             => $theme_support['view-type-default'],
+			'show_title'            => $theme_support['title-default'],
+			'show_author'           => $theme_support['author-default'],
+			'show_date'             => $theme_support['date-default'],
+			'stories_archive_label' => $theme_support['stories-archive-label'],
+			'show_story_poster'     => $theme_support['show-story-poster-default'],
+			'number_of_columns'     => $theme_support['grid-columns-default'],
 		];
 
 		$query_arguments = [
-			'posts_per_page' => ( ! empty( $theme_support['number-of-stories'] ) && is_numeric( $theme_support['number-of-stories'] ) ) ? $theme_support['number-of-stories'] : 5,
+			'posts_per_page' => ! empty( $options['number_of_stories'] ) ? $options['number_of_stories'] : $theme_support['number-of-stories'],
 		];
 
-		$query_arguments['posts_per_page'] = ! empty( $options['number_of_stories'] ) ? $options['number_of_stories'] : $query_arguments['posts_per_page'];
-
-		$order_by = ! empty( $theme_support['order-default'] ) ? $theme_support['order-default'] : 'latest';
-		$order_by = ! empty( $options['order'] ) ? $options['order'] : $order_by;
+		$order_by = ! empty( $options['order'] ) ? $options['order'] : $theme_support['order-default'];
 
 		switch ( $order_by ) {
 			case 'oldest':

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -528,7 +528,7 @@ class Customizer {
 	/**
 	 * Renders web stories based on the customizer selected options.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public static function render_stories() {
 		$options = get_option( 'story-options' );

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -1,0 +1,589 @@
+<?php
+/**
+ * Class Customizer
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories;
+
+/**
+ * Class Database_Upgrader
+ *
+ * @package Google\Web_Stories
+ */
+class Customizer {
+
+	/**
+	 * Customizer section slug.
+	 *
+	 * @var string
+	 */
+	const SECTION_SLUG = 'web_story_options';
+
+	/**
+	 * Experiments instance.
+	 *
+	 * @var \WP_Customize_Manager $wp_customize WP_Customize_Manager instance.
+	 */
+	private $wp_customize;
+
+	/**
+	 * Initializes the customizer logic.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'customize_register', [ $this, 'register_customizer_settings' ] );
+	}
+
+	/**
+	 * Registers customizer settings for web stories.
+	 *
+	 * @param \WP_Customize_Manager $wp_customize WP_Customize_Manager instance.
+	 *
+	 * @return void
+	 */
+	public function register_customizer_settings( \WP_Customize_Manager $wp_customize ) {
+
+		$this->wp_customize = $wp_customize;
+
+		$options = get_theme_support( 'web-story-options' );
+
+		$view_type         = ( ! empty( $options[0]['view-type'] ) && is_array( $options[0]['view-type'] ) ) ? $options[0]['view-type'] : [];
+		$view_type_default = ( ! empty( $options[0]['view-type-default'] ) ) ? $options[0]['view-type-default'] : 'circles';
+
+		$show_title         = ( ! empty( $options[0]['title'] ) ) ? $options[0]['title'] : false;
+		$show_title_default = ( ! empty( $options[0]['title-default'] ) ) ? $options[0]['title-default'] : false;
+
+		$show_author         = ( ! empty( $options[0]['author'] ) ) ? $options[0]['author'] : false;
+		$show_author_default = ( ! empty( $options[0]['author-default'] ) ) ? $options[0]['author-default'] : false;
+
+		$show_date         = ( ! empty( $options[0]['date'] ) ) ? $options[0]['date'] : false;
+		$show_date_default = ( ! empty( $options[0]['date-default'] ) ) ? $options[0]['date-default'] : false;
+
+		$show_stories_archive_link = ( ! empty( $options[0]['stories-archive-link'] ) ) ? $options[0]['stories-archive-link'] : false;
+		$stories_archive_label     = ( ! empty( $options[0]['stories-archive-label'] ) ) ? $options[0]['stories-archive-label'] : 'View all stories';
+
+		$number_of_stories = ( ! empty( $options[0]['number-of-stories'] ) && is_numeric( $options[0]['number-of-stories'] ) ) ? $options[0]['number-of-stories'] : 5;
+
+		$order         = ( ! empty( $options[0]['order'] ) && is_array( $options[0]['order'] ) ) ? $options[0]['order'] : [];
+		$order_default = ( ! empty( $options[0]['order-default'] ) ) ? $options[0]['order-default'] : 'latest';
+
+		$show_story_poster_default = ( ! empty( $options[0]['show-story-poster-default'] ) ) ? $options[0]['show-story-poster-default'] : true;
+
+		$number_of_columns_default = ( ! empty( $options[0]['grid-columns-default'] ) && is_numeric( $options[0]['grid-columns-default'] ) ) ? $options[0]['grid-columns-default'] : 2;
+
+		// Add Content section.
+		$wp_customize->add_section(
+			self::SECTION_SLUG,
+			[
+				'title'          => esc_html__( 'Web Story Options', 'web-stories' ),
+				'theme_supports' => 'web-story-options',
+			]
+		);
+
+		$wp_customize->add_setting(
+			'story-options[show_stories]',
+			[
+				'default' => false,
+				'type'    => 'option',
+			]
+		);
+
+		$wp_customize->add_control(
+			'story-options[show_stories]',
+			[
+				'type'    => 'checkbox',
+				'section' => self::SECTION_SLUG,
+				'label'   => __( 'Show stories', 'web-stories' ),
+			]
+		);
+
+		$wp_customize->add_setting(
+			'story-options[view_type]',
+			[
+				'default' => $view_type_default,
+				'type'    => 'option',
+			]
+		);
+
+		$wp_customize->add_control(
+			'story-options[view_type]',
+			[
+				'section'         => self::SECTION_SLUG,
+				'label'           => __( 'Story view type', 'web-stories' ),
+				'type'            => 'select',
+				'choices'         => $this->get_view_type_choices( $view_type ),
+				'active_callback' => function() {
+					return $this->is_option_enabled( 'show_stories' );
+				},
+			]
+		);
+
+		$wp_customize->add_setting(
+			'story-options[number_of_stories]',
+			[
+				'default'           => $number_of_stories,
+				'type'              => 'option',
+				'validate_callback' => [ $this, 'validate_number_of_stories' ],
+			]
+		);
+
+		$wp_customize->add_control(
+			'story-options[number_of_stories]',
+			[
+				'type'            => 'number',
+				'section'         => self::SECTION_SLUG,
+				'label'           => __( 'Number of stories', 'web-stories' ),
+				'input_attrs'     => [
+					'min' => 1,
+					'max' => 20,
+				],
+				'active_callback' => function() {
+					return $this->is_option_enabled( 'show_stories' );
+				},
+			]
+		);
+
+		$wp_customize->add_setting(
+			'story-options[number_of_columns]',
+			[
+				'default'           => $number_of_columns_default,
+				'type'              => 'option',
+				'validate_callback' => [ $this, 'validate_number_of_columns' ],
+			]
+		);
+
+		$wp_customize->add_control(
+			'story-options[number_of_columns]',
+			[
+				'type'            => 'number',
+				'section'         => self::SECTION_SLUG,
+				'label'           => __( 'Number of columns', 'web-stories' ),
+				'input_attrs'     => [
+					'min' => 1,
+					'max' => 4,
+				],
+				'active_callback' => function() {
+					return ( $this->is_option_enabled( 'show_stories' ) && $this->is_view_type( 'grid' ) );
+				},
+			]
+		);
+
+		$wp_customize->add_setting(
+			'story-options[order]',
+			[
+				'default' => $order_default,
+				'type'    => 'option',
+			]
+		);
+
+		$wp_customize->add_control(
+			'story-options[order]',
+			[
+				'section'         => self::SECTION_SLUG,
+				'label'           => __( 'Order by', 'web-stories' ),
+				'type'            => 'select',
+				'choices'         => $this->get_order_choices( $order ),
+				'active_callback' => function() {
+					return $this->is_option_enabled( 'show_stories' );
+				},
+			]
+		);
+
+		$wp_customize->add_setting(
+			'story-options[list_view_image_alignment]',
+			[
+				'type'    => 'option',
+				'default' => 'left',
+			]
+		);
+
+		$wp_customize->add_control(
+			'story-options[list_view_image_alignment]',
+			[
+				'type'            => 'radio',
+				'section'         => self::SECTION_SLUG,
+				'label'           => __( 'Image alignment', 'web-stories' ),
+				'choices'         => [
+					'left'  => __( 'Left', 'web-stories' ),
+					'right' => __( 'Right', 'web-stories' ),
+				],
+				'active_callback' => function() {
+					return ( $this->is_option_enabled( 'show_stories' ) && $this->is_view_type( 'list' ) );
+				},
+			]
+		);
+
+		if ( true === $show_title ) {
+
+			$wp_customize->add_setting(
+				'story-options[show_title]',
+				[
+					'default' => $show_title_default,
+					'type'    => 'option',
+				]
+			);
+
+			$wp_customize->add_control(
+				'story-options[show_title]',
+				[
+					'type'            => 'checkbox',
+					'section'         => self::SECTION_SLUG,
+					'label'           => __( 'Show story title', 'web-stories' ),
+					'active_callback' => function() {
+						return $this->is_option_enabled( 'show_stories' ) && ! $this->is_view_type( 'circles' );
+					},
+				]
+			);
+		}
+
+		if ( true === $show_author ) {
+			$wp_customize->add_setting(
+				'story-options[show_author]',
+				[
+					'default' => $show_author_default,
+					'type'    => 'option',
+				]
+			);
+
+			$wp_customize->add_control(
+				'story-options[show_author]',
+				[
+					'type'            => 'checkbox',
+					'section'         => self::SECTION_SLUG,
+					'label'           => __( 'Show author', 'web-stories' ),
+					'active_callback' => function() {
+						return ( $this->is_option_enabled( 'show_stories' ) && ! $this->is_view_type( 'circles' ) );
+					},
+				]
+			);
+		}
+
+		if ( true === $show_date ) {
+			$wp_customize->add_setting(
+				'story-options[show_date]',
+				[
+					'default' => $show_date_default,
+					'type'    => 'option',
+				]
+			);
+
+			$wp_customize->add_control(
+				'story-options[show_date]',
+				[
+					'type'            => 'checkbox',
+					'section'         => self::SECTION_SLUG,
+					'label'           => __( 'Show date', 'web-stories' ),
+					'active_callback' => function() {
+						return ( $this->is_option_enabled( 'show_stories' ) && ! $this->is_view_type( 'circles' ) );
+					},
+				]
+			);
+		}
+
+		$wp_customize->add_setting(
+			'story-options[show_square_corners]',
+			[
+				'default' => false,
+				'type'    => 'option',
+			]
+		);
+
+		$wp_customize->add_control(
+			'story-options[show_square_corners]',
+			[
+				'type'            => 'checkbox',
+				'section'         => self::SECTION_SLUG,
+				'label'           => __( 'Show square corners', 'web-stories' ),
+				'active_callback' => function() {
+					return ( $this->is_option_enabled( 'show_stories' ) && ! $this->is_view_type( 'circles' ) );
+				},
+			]
+		);
+
+		if ( true === $show_stories_archive_link ) {
+			$wp_customize->add_setting(
+				'story-options[show_stories_archive_link]',
+				[
+					'default' => false,
+					'type'    => 'option',
+				]
+			);
+
+			$wp_customize->add_control(
+				'story-options[show_stories_archive_link]',
+				[
+					'type'            => 'checkbox',
+					'section'         => self::SECTION_SLUG,
+					'label'           => __( 'Show stories archive link', 'web-stories' ),
+					'active_callback' => function() {
+						return $this->is_option_enabled( 'show_stories' );
+					},
+				]
+			);
+
+			$wp_customize->add_setting(
+				'story-options[stories_archive_label]',
+				[
+					'type'    => 'option',
+					'default' => $stories_archive_label,
+				]
+			);
+
+			$wp_customize->add_control(
+				'story-options[stories_archive_label]',
+				[
+					'type'            => 'text',
+					'section'         => self::SECTION_SLUG,
+					'label'           => __( 'Stories archive label', 'web-stories' ),
+					'active_callback' => function() {
+						return ( $this->is_option_enabled( 'show_stories' ) && $this->is_option_enabled( 'show_stories_archive_link' ) );
+					},
+				]
+			);
+
+			$wp_customize->add_setting(
+				'story-options[show_story_poster]',
+				[
+					'default' => $show_story_poster_default,
+					'type'    => 'option',
+				]
+			);
+
+			$wp_customize->add_control(
+				'story-options[show_story_poster]',
+				[
+					'type'            => 'checkbox',
+					'section'         => self::SECTION_SLUG,
+					'label'           => __( 'Show story poster', 'web-stories' ),
+					'active_callback' => function() {
+						return ( $this->is_option_enabled( 'show_stories' ) && $this->is_view_type( 'grid' ) );
+					},
+				]
+			);
+
+		}
+
+	}
+
+	/**
+	 * Gets the view type choices.
+	 *
+	 * @param array $view_type View type to check.
+	 *
+	 * @return array An array of view type choices.
+	 */
+	protected function get_view_type_choices( $view_type ) {
+
+		if ( empty( $view_type ) ) {
+			return [ 'circles' => __( 'Circles', 'web-stories' ) ];
+		}
+
+		$view_type_choices = [];
+
+		if ( in_array( 'circles', $view_type ) ) {
+			$view_type_choices['circles'] = __( 'Circles', 'web-stories' );
+		}
+
+		if ( in_array( 'grid', $view_type ) ) {
+			$view_type_choices['grid'] = __( 'Grid', 'web-stories' );
+		}
+
+		if ( in_array( 'list', $view_type ) ) {
+			$view_type_choices['list'] = __( 'List', 'web-stories' );
+		}
+
+		if ( in_array( 'carousel', $view_type ) ) {
+			$view_type_choices['carousel'] = __( 'Carousel', 'web-stories' );
+		}
+
+		return $view_type_choices;
+
+	}
+
+
+	/**
+	 * Gets the order choices.
+	 *
+	 * @param array $order An array of order support.
+	 *
+	 * @return array An array of order choices.
+	 */
+	protected function get_order_choices( $order ) {
+
+		$order_choices = [];
+
+		if ( empty( $order ) ) {
+			return [
+				'latest'               => __( 'Latest', 'web-stories' ),
+				'oldest'               => __( 'Oldest', 'web-stories' ),
+				'alphabetical'         => __( 'A -> Z', 'web-stories' ),
+				'reverse-alphabetical' => __( 'Z -> A', 'web-stories' ),
+			];
+		}
+
+		if ( in_array( 'latest', $order ) ) {
+			$order_choices['latest'] = __( 'Latest', 'web-stories' );
+		}
+
+		if ( in_array( 'oldest', $order ) ) {
+			$order_choices['oldest'] = __( 'Oldest', 'web-stories' );
+		}
+
+		if ( in_array( 'alphabetical', $order ) ) {
+			$order_choices['alphabetical'] = __( 'A -> Z', 'web-stories' );
+		}
+
+		if ( in_array( 'reverse-alphabetical', $order ) ) {
+			$order_choices['reverse-alphabetical'] = __( 'Z -> A', 'web-stories' );
+		}
+
+		return $order_choices;
+
+	}
+
+	/**
+	 * Checks whether the given option is enabled or not.
+	 *
+	 * @param string $option_name The name of the option to check.
+	 *
+	 * @return boolean Returns true if the given option is enabled otherwise false.
+	 */
+	protected function is_option_enabled( $option_name ) {
+		$setting = $this->wp_customize->get_setting( "story-options[{$option_name}]" );
+		return ( $setting instanceof \WP_Customize_Setting && true === $setting->value() );
+	}
+
+	/**
+	 * Verifies the current view type.
+	 *
+	 * @param string $view_type View type to check.
+	 *
+	 * @return bool Whether or not current view type matches the one passed.
+	 */
+	protected function is_view_type( $view_type ) {
+		$setting = $this->wp_customize->get_setting( 'story-options[view_type]' );
+		return ( $setting instanceof \WP_Customize_Setting && $view_type === $setting->value() );
+	}
+
+	/**
+	 * Validates the number of story setting value.
+	 *
+	 * @param \WP_Error $validity WP_Error object.
+	 * @param int       $value    Value to be validated.
+	 *
+	 * @return \WP_Error
+	 */
+	public function validate_number_of_stories( $validity, $value ) {
+		$value = intval( $value );
+
+		if ( $value <= 0 ) {
+			$validity->add( 'invalid_number', __( 'The number of stories must be between 1 and 20.', 'web-stories' ) );
+		} elseif ( $value > 20 ) {
+			$validity->add( 'invalid_number', __( 'The number of stories must be between 1 and 20.', 'web-stories' ) );
+		}
+		return $validity;
+	}
+
+	/**
+	 * Validates the number of columns setting value.
+	 *
+	 * @param \WP_Error $validity WP_Error object.
+	 * @param int       $value Value to be validated.
+	 *
+	 * @return \WP_Error
+	 */
+	public function validate_number_of_columns( $validity, $value ) {
+		$value = intval( $value );
+
+		if ( $value <= 0 ) {
+			$validity->add( 'invalid_number', __( 'The number of stories must be between 1 and 4.', 'web-stories' ) );
+		} elseif ( $value > 5 ) {
+			$validity->add( 'invalid_number', __( 'The number of stories must be between 1 and 4.', 'web-stories' ) );
+		}
+		return $validity;
+	}
+
+	/**
+	 * Renders web stories based on the customizer selected options.
+	 *
+	 * @return string
+	 */
+	public static function render_stories() {
+		$options = get_option( 'story-options' );
+
+		if ( empty( $options['show_stories'] ) || true !== $options['show_stories'] ) {
+			return;
+		}
+
+		$theme_support = get_theme_support( 'web-story-options' );
+
+		$default_array = [
+			'view_type'             => ( ! empty( $theme_support[0]['view-type-default'] ) ) ? $theme_support[0]['view-type-default'] : 'circles',
+			'show_title'            => ( ! empty( $theme_support[0]['title-default'] ) ) ? $theme_support[0]['title-default'] : false,
+			'show_author'           => ( ! empty( $theme_support[0]['author-default'] ) ) ? $theme_support[0]['author-default'] : false,
+			'show_date'             => ( ! empty( $theme_support[0]['date-default'] ) ) ? $theme_support[0]['date-default'] : false,
+			'stories_archive_label' => ( ! empty( $theme_support[0]['stories-archive-label'] ) ) ? $theme_support[0]['stories-archive-label'] : 'View all stories',
+			'show_story_poster'     => ( ! empty( $theme_support[0]['show-story-poster-default'] ) ) ? $theme_support[0]['show-story-poster-default'] : true,
+			'number_of_columns'     => ( ! empty( $theme_support[0]['grid-columns-default'] ) && is_numeric( $theme_support[0]['grid-columns-default'] ) ) ? $theme_support[0]['grid-columns-default'] : 2,
+		];
+
+		$query_arguments = [
+			'posts_per_page' => ( ! empty( $theme_support[0]['number-of-stories'] ) && is_numeric( $theme_support[0]['number-of-stories'] ) ) ? $theme_support[0]['number-of-stories'] : 5,
+		];
+
+		$query_arguments['posts_per_page'] = ! empty( $options['number_of_stories'] ) ? $options['number_of_stories'] : $query_arguments['posts_per_page'];
+
+		$order_by = ! empty( $theme_support[0]['order-default'] ) ? $theme_support[0]['order-default'] : 'latest';
+		$order_by = ! empty( $options['order'] ) ? $options['order'] : $order_by;
+
+		switch ( $order_by ) {
+			case 'oldest':
+				$query_arguments['order'] = 'ASC';
+				break;
+			case 'alphabetical':
+				$query_arguments['orderby'] = 'title';
+				$query_arguments['order']   = 'ASC';
+				break;
+			case 'reverse-alphabetical':
+				$query_arguments['orderby'] = 'title';
+				$query_arguments['order']   = 'DESC';
+				break;
+			case 'random':
+				$query_arguments['orderby'] = 'rand';
+				$query_arguments['order']   = 'DESC';
+				break;
+		}
+
+		$story_arguments = wp_parse_args( $options, $default_array );
+
+		$story_arguments['class'] = 'web-stories-list--customizer';
+
+		$stories = new Stories( $story_arguments, $query_arguments );
+
+		return $stories->render();
+
+	}
+
+}

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -571,7 +571,7 @@ class Customizer {
 				$query_arguments['order']   = 'DESC';
 				break;
 			case 'random':
-				$query_arguments['orderby'] = 'rand';
+				$query_arguments['orderby'] = 'rand'; //phpcs:ignore WordPressVIPMinimum.Performance.OrderByRand.orderby_orderby
 				$query_arguments['order']   = 'DESC';
 				break;
 		}

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -284,26 +284,6 @@ class Customizer {
 			);
 		}
 
-		$wp_customize->add_setting(
-			'story-options[show_square_corners]',
-			[
-				'default' => false,
-				'type'    => 'option',
-			]
-		);
-
-		$wp_customize->add_control(
-			'story-options[show_square_corners]',
-			[
-				'type'            => 'checkbox',
-				'section'         => self::SECTION_SLUG,
-				'label'           => __( 'Show square corners', 'web-stories' ),
-				'active_callback' => function() {
-					return ( $this->is_option_enabled( 'show_stories' ) && ! $this->is_view_type( 'circles' ) );
-				},
-			]
-		);
-
 		if ( true === $theme_support['stories-archive-link'] ) {
 			$wp_customize->add_setting(
 				'story-options[show_stories_archive_link]',

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -43,7 +43,7 @@ class Customizer {
 	const SECTION_SLUG = 'web_story_options';
 
 	/**
-	 * Experiments instance.
+	 * WP_Customize_Manager instance.
 	 *
 	 * @var \WP_Customize_Manager $wp_customize WP_Customize_Manager instance.
 	 */
@@ -59,7 +59,7 @@ class Customizer {
 	}
 
 	/**
-	 * Registers customizer settings for web stories.
+	 * Registers web stories customizer settings.
 	 *
 	 * @param \WP_Customize_Manager $wp_customize WP_Customize_Manager instance.
 	 *

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -27,7 +27,9 @@
 namespace Google\Web_Stories;
 
 /**
- * Class Database_Upgrader
+ * Class customizer settings.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  *
  * @package Google\Web_Stories
  */
@@ -60,6 +62,10 @@ class Customizer {
 	 * Registers customizer settings for web stories.
 	 *
 	 * @param \WP_Customize_Manager $wp_customize WP_Customize_Manager instance.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @return void
 	 */
@@ -527,6 +533,9 @@ class Customizer {
 
 	/**
 	 * Renders web stories based on the customizer selected options.
+	 *
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @return string|void
 	 */

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -152,6 +152,13 @@ class Plugin {
 	public $integrations = [];
 
 	/**
+	 * Customizer.
+	 *
+	 * @var Customizer
+	 */
+	public $customizer;
+
+	/**
 	 * Initialize plugin functionality.
 	 *
 	 * @since 1.0.0
@@ -177,6 +184,9 @@ class Plugin {
 
 		$this->admin = new Admin();
 		add_action( 'admin_init', [ $this->admin, 'init' ] );
+
+		$this->customizer = new Customizer();
+		add_action( 'init', [ $this->customizer, 'init' ] );
 
 		$this->media = new Media();
 		add_action( 'init', [ $this->media, 'init' ] );

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -44,6 +44,8 @@ use Google\Web_Stories\Shortcode\Embed_Shortcode;
 
 /**
  * Plugin class.
+ *
+ * @SuppressWarnings(PHPMD.TooManyFields)
  */
 class Plugin {
 	/**

--- a/tests/phpunit/tests/Customizer.php
+++ b/tests/phpunit/tests/Customizer.php
@@ -216,7 +216,7 @@ class Customizer extends \WP_UnitTestCase {
 			'show_stories' => true,
 		];
 
-		$output = get_echo( [ $this->customizer, 'render_stories' ] );
+		$output = $this->customizer->render_stories();
 
 		$this->assertEmpty( $output );
 
@@ -228,7 +228,7 @@ class Customizer extends \WP_UnitTestCase {
 			]
 		);
 
-		$output = get_echo( [ $this->customizer, 'render_stories' ] );
+		$output = $this->customizer->render_stories();
 
 		$this->assertNotEmpty( $output );
 

--- a/tests/phpunit/tests/Customizer.php
+++ b/tests/phpunit/tests/Customizer.php
@@ -129,9 +129,6 @@ class Customizer extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_author]' ) );
 		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_author]' ) );
 
-		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_square_corners]' ) );
-		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_square_corners]' ) );
-
 		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_date]' ) );
 		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_date]' ) );
 

--- a/tests/phpunit/tests/Customizer.php
+++ b/tests/phpunit/tests/Customizer.php
@@ -129,6 +129,9 @@ class Customizer extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_author]' ) );
 		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_author]' ) );
 
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_square_corners]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_square_corners]' ) );
+
 		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_date]' ) );
 		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_date]' ) );
 

--- a/tests/phpunit/tests/Customizer.php
+++ b/tests/phpunit/tests/Customizer.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+namespace Google\Web_Stories\Tests;
+
+use WP_Error;
+
+/**
+ * @coversDefaultClass \Google\Web_Stories\Customizer
+ */
+class Customizer extends \WP_UnitTestCase {
+
+	/**
+	 * Instance of WP_Customize_Manager which is reset for each test.
+	 *
+	 * @var WP_Customize_Manager
+	 */
+	public $wp_customize;
+
+	public static function wpSetUpBeforeClass() {
+		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
+	}
+
+	/**
+	 * Runs once before any test in the class run.
+	 */
+	public function setUp() {
+
+		global $wp_customize;
+
+		$this->customizer   = new \Google\Web_Stories\Customizer();
+		$this->wp_customize = new \WP_Customize_Manager();
+		$wp_customize       = $this->wp_customize;
+
+	}
+
+	public function test_init() {
+
+		$this->customizer->init();
+		$this->assertSame( 10, has_action( 'customize_register', [ $this->customizer, 'register_customizer_settings' ] ) );
+	}
+
+	/**
+	 * @covers ::register_customizer_settings
+	 * @covers ::get_order_choices
+	 * @covers ::get_view_type_choices
+	 */
+	public function test_register_customizer_settings() {
+
+		add_theme_support(
+			'web-story-options',
+			[
+				'view-type'                 => [ 'circles', 'grid', 'list', 'carousel' ],
+				'view-type-default'         => 'circles',
+				'grid-columns-default'      => 4,
+				'title'                     => true,
+				'title-default'             => false,
+				'author'                    => true,
+				'author-default'            => false,
+				'date'                      => true,
+				'date-default'              => false,
+				'stories-archive-link'      => true,
+				'stories-archive-label'     => 'View all stories',
+				'number-of-stories'         => 5,
+				'order'                     => [ 'alphabetical', 'reverse-alphabetical', 'latest', 'oldest' ],
+				'order-default'             => 'oldest',
+				'show-story-poster-default' => true,
+			]
+		);
+
+		$this->customizer->register_customizer_settings( $this->wp_customize );
+
+		$this->assertNotEmpty( $this->wp_customize->get_section( \Google\Web_Stories\Customizer::SECTION_SLUG ) );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_stories]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_stories]' ) );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[view_type]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[view_type]' ) );
+
+		$expected_view_choices = [
+			'circles'  => __( 'Circles', 'web-stories' ),
+			'grid'     => __( 'Grid', 'web-stories' ),
+			'list'     => __( 'List', 'web-stories' ),
+			'carousel' => __( 'Carousel', 'web-stories' ),
+		];
+
+		$this->assertEquals( $expected_view_choices, $this->wp_customize->get_control( 'story-options[view_type]' )->choices );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[number_of_stories]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[number_of_stories]' ) );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[number_of_columns]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[number_of_columns]' ) );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[order]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[order]' ) );
+
+		$expected_order_choices = [
+			'latest'               => __( 'Latest', 'web-stories' ),
+			'oldest'               => __( 'Oldest', 'web-stories' ),
+			'alphabetical'         => __( 'A -> Z', 'web-stories' ),
+			'reverse-alphabetical' => __( 'Z -> A', 'web-stories' ),
+		];
+
+		$this->assertEquals( $expected_order_choices, $this->wp_customize->get_control( 'story-options[order]' )->choices );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[list_view_image_alignment]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[list_view_image_alignment]' ) );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_title]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_title]' ) );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_author]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_author]' ) );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_date]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_date]' ) );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_stories_archive_link]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_stories_archive_link]' ) );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[stories_archive_label]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[stories_archive_label]' ) );
+
+		$this->assertNotEmpty( $this->wp_customize->get_setting( 'story-options[show_story_poster]' ) );
+		$this->assertNotEmpty( $this->wp_customize->get_control( 'story-options[show_story_poster]' ) );
+
+	}
+
+	/**
+	 * @covers ::validate_number_of_stories
+	 */
+	public function test_validate_number_of_stories() {
+		$output = $this->customizer->validate_number_of_stories( new WP_Error(), 20 );
+
+		$this->assertEmpty( $output->errors );
+
+		$output = $this->customizer->validate_number_of_stories( new WP_Error(), 30 );
+
+		$this->assertNotEmpty( $output->errors );
+		$this->assertNotEmpty( $output->errors['invalid_number'] );
+
+		$output = $this->customizer->validate_number_of_stories( new WP_Error(), 0 );
+
+		$this->assertNotEmpty( $output->errors );
+		$this->assertNotEmpty( $output->errors['invalid_number'] );
+
+	}
+
+	/**
+	 * @covers ::validate_number_of_columns
+	 */
+	public function test_validate_number_of_columns() {
+		$output = $this->customizer->validate_number_of_columns( new WP_Error(), 2 );
+
+		$this->assertEmpty( $output->errors );
+
+		$output = $this->customizer->validate_number_of_columns( new WP_Error(), 6 );
+
+		$this->assertNotEmpty( $output->errors );
+		$this->assertNotEmpty( $output->errors['invalid_number'] );
+
+		$output = $this->customizer->validate_number_of_columns( new WP_Error(), 0 );
+
+		$this->assertNotEmpty( $output->errors );
+		$this->assertNotEmpty( $output->errors['invalid_number'] );
+
+	}
+
+	/**
+	 * @covers ::render_stories
+	 */
+	public function test_render_stories() {
+
+		add_theme_support(
+			'web-story-options',
+			[
+				'view-type'                 => [ 'circles', 'grid', 'list', 'carousel' ],
+				'view-type-default'         => 'circles',
+				'grid-columns-default'      => 4,
+				'title'                     => true,
+				'title-default'             => false,
+				'author'                    => true,
+				'author-default'            => false,
+				'date'                      => true,
+				'date-default'              => false,
+				'stories-archive-link'      => true,
+				'stories-archive-label'     => 'View all stories',
+				'number-of-stories'         => 5,
+				'order'                     => [ 'alphabetical', 'reverse-alphabetical', 'latest', 'oldest' ],
+				'order-default'             => 'oldest',
+				'show-story-poster-default' => true,
+			]
+		);
+
+		$options = [
+			'show_stories' => true,
+		];
+
+		$output = get_echo( [ $this->customizer, 'render_stories' ] );
+
+		$this->assertEmpty( $output );
+
+		update_option( 'story-options', $options );
+
+		$this->factory->post->create(
+			[
+				'post_type' => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+			]
+		);
+
+		$output = get_echo( [ $this->customizer, 'render_stories' ] );
+
+		$this->assertNotEmpty( $output );
+
+		$this->assertContains( 'web-stories-list--customizer', $output );
+
+	}
+
+}

--- a/tests/phpunit/tests/Customizer.php
+++ b/tests/phpunit/tests/Customizer.php
@@ -187,6 +187,36 @@ class Customizer extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::get_stories_theme_support
+	 */
+	public function test_get_stories_theme_support() {
+
+		add_theme_support( 'web-story-options' );
+
+		$expected = [
+			'view-type'                 => [],
+			'view-type-default'         => 'circles',
+			'grid-columns-default'      => 2,
+			'title'                     => false,
+			'title-default'             => false,
+			'author'                    => false,
+			'author-default'            => false,
+			'date'                      => false,
+			'date-default'              => false,
+			'stories-archive-link'      => true,
+			'stories-archive-label'     => __( 'View all stories', 'web-stories' ),
+			'number-of-stories'         => 5,
+			'order'                     => [],
+			'order-default'             => 'oldest',
+			'show-story-poster-default' => true,
+		];
+
+		$output = $this->customizer->get_stories_theme_support();
+
+		$this->assertEquals( $expected, $output );
+	}
+
+	/**
 	 * @covers ::render_stories
 	 */
 	public function test_render_stories() {


### PR DESCRIPTION
Depends on #38 

## Summary

- Add customizer settings to display web stories list.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
- Add theme support for web stories options in your theme's functions.php
```php
add_theme_support( 'web-story-options' );
```
Advanced options and defaults
```php
add_theme_support(
	'web-story-options',
	[
		'view-type'                 => [ 'circles', 'grid', 'list', 'carousel' ],
		'view-type-default'         => 'circles',
		'grid-columns-default'      => 4,
		'title'                     => true,
		'title-default'             => false,
		'author'                    => true,
		'author-default'            => false,
		'date'                      => true,
		'date-default'              => false,
		'stories-archive-link'      => true,
		'stories-archive-label'     => 'View all stories',
		'number-of-stories'         => 5,
		'order'                     => [ 'alphabetical', 'reverse-alphabetical', 'latest', 'oldest' ],
		'order-default'             => 'oldest',
		'show-story-poster-default' => true,
	]
);
```
- Use the Customizer::render_stories method in the desired area in the theme.
```php
echo Customizer::render_stories();
```
- Enable show web stories option from customizer in the `Web story options` section.

PS: The show square corners option will not work that needs to be handled inside the Renderer classes.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #8 
