### PR TITLE
Stories shortcode API

### DIFF
--- a/includes/Interfaces/Renderer.php
+++ b/includes/Interfaces/Renderer.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Renderer Interface.
+ *
+ * Stories renderers should conform to this interface,
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Interfaces;
+
+interface Renderer {
+
+	/**
+	 * Initial actions to setup the renderer like,
+	 * adding hooks and setting up states.
+	 *
+	 * @return void
+	 */
+	public function init();
+
+	/**
+	 * Render the markup for story.
+	 *
+	 * @return string
+	 */
+	public function render();
+
+	/**
+	 * Render a single story markup.
+	 *
+	 * @return mixed
+	 */
+	public function render_single_story_content();
+}

--- a/includes/Model/Story.php
+++ b/includes/Model/Story.php
@@ -95,13 +95,6 @@ class Story {
 	protected $author;
 
 	/**
-	 * Whether content overlay is enabled for story.
-	 *
-	 * @var bool
-	 */
-	protected $content_overlay;
-
-	/**
 	 * Story constructor.
 	 *
 	 * @since 1.0.0
@@ -220,15 +213,6 @@ class Story {
 	 */
 	public function get_id() {
 		return $this->id;
-	}
-
-	/**
-	 * Check whether content overlay is enabled for story.
-	 *
-	 * @return bool
-	 */
-	public function get_content_overlay() {
-		return $this->content_overlay;
 	}
 
 	/**

--- a/includes/Model/Story.php
+++ b/includes/Model/Story.php
@@ -81,27 +81,6 @@ class Story {
 	protected $poster_square;
 
 	/**
-	 * Height for displaying story.
-	 *
-	 * @var int
-	 */
-	protected $height;
-
-	/**
-	 * Width for displaying story.
-	 *
-	 * @var int
-	 */
-	protected $width;
-
-	/**
-	 * Classes for story.
-	 *
-	 * @var string
-	 */
-	protected $classes;
-
-	/**
 	 * Date for the story.
 	 *
 	 * @var string
@@ -253,24 +232,6 @@ class Story {
 	}
 
 	/**
-	 * Height for the story.
-	 *
-	 * @return int
-	 */
-	public function get_height() {
-		return $this->height;
-	}
-
-	/**
-	 * Width for the story.
-	 *
-	 * @return int
-	 */
-	public function get_width() {
-		return $this->width;
-	}
-
-	/**
 	 * Get author of the story.
 	 *
 	 * @return string
@@ -288,12 +249,4 @@ class Story {
 		return $this->date;
 	}
 
-	/**
-	 * HTML classes for the story.
-	 *
-	 * @return string
-	 */
-	public function get_classes() {
-		return $this->classes;
-	}
 }

--- a/includes/Model/Story.php
+++ b/includes/Model/Story.php
@@ -37,6 +37,13 @@ use WP_Post;
  */
 class Story {
 	/**
+	 * Story ID.
+	 *
+	 * @var int
+	 */
+	protected $id;
+
+	/**
 	 * Title.
 	 *
 	 * @var string
@@ -72,6 +79,48 @@ class Story {
 	 * @var string
 	 */
 	protected $poster_square;
+
+	/**
+	 * Height for displaying story.
+	 *
+	 * @var int
+	 */
+	protected $height;
+
+	/**
+	 * Width for displaying story.
+	 *
+	 * @var int
+	 */
+	protected $width;
+
+	/**
+	 * Classes for story.
+	 *
+	 * @var string
+	 */
+	protected $classes;
+
+	/**
+	 * Date for the story.
+	 *
+	 * @var string
+	 */
+	protected $date;
+
+	/**
+	 * Author of story.
+	 *
+	 * @var string
+	 */
+	protected $author;
+
+	/**
+	 * Whether content overlay is enabled for story.
+	 *
+	 * @var bool
+	 */
+	protected $content_overlay;
 
 	/**
 	 * Story constructor.
@@ -183,5 +232,68 @@ class Story {
 	 */
 	public function get_poster_square() {
 		return $this->poster_square;
+	}
+
+	/**
+	 * Get the story ID.
+	 *
+	 * @return int
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+
+	/**
+	 * Check whether content overlay is enabled for story.
+	 *
+	 * @return bool
+	 */
+	public function get_content_overlay() {
+		return $this->content_overlay;
+	}
+
+	/**
+	 * Height for the story.
+	 *
+	 * @return int
+	 */
+	public function get_height() {
+		return $this->height;
+	}
+
+	/**
+	 * Width for the story.
+	 *
+	 * @return int
+	 */
+	public function get_width() {
+		return $this->width;
+	}
+
+	/**
+	 * Get author of the story.
+	 *
+	 * @return string
+	 */
+	public function get_author() {
+		return $this->author;
+	}
+
+	/**
+	 * Date for the story.
+	 *
+	 * @return string
+	 */
+	public function get_date() {
+		return $this->date;
+	}
+
+	/**
+	 * HTML classes for the story.
+	 *
+	 * @return string
+	 */
+	public function get_classes() {
+		return $this->classes;
 	}
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -41,6 +41,7 @@ use Google\Web_Stories\Block\Embed_Block;
 use Google\Web_Stories\REST_API\Stories_Settings_Controller;
 use Google\Web_Stories\REST_API\Stories_Users_Controller;
 use Google\Web_Stories\Shortcode\Embed_Shortcode;
+use Google\Web_Stories\Shortcode\Stories_Shortcode;
 
 /**
  * Plugin class.
@@ -205,6 +206,9 @@ class Plugin {
 		// Embed shortcode.
 		$this->embed_shortcode = new Embed_Shortcode();
 		add_action( 'init', [ $this->embed_shortcode, 'init' ] );
+
+		$story_shortcode = new Stories_Shortcode();
+		add_action( 'init', [ $story_shortcode, 'init' ] );
 
 		// Frontend.
 		$this->discovery = new Discovery();

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -162,6 +162,7 @@ class Plugin {
 	public function register() {
 		// Plugin compatibility / polyfills.
 		add_action( 'wp', [ $this, 'load_amp_plugin_compat' ] );
+		add_action( 'rest_api_init', [ $this, 'load_amp_plugin_compat' ] );
 
 		// Settings.
 		$this->settings = new Settings();

--- a/includes/Shortcode/Stories_Shortcode.php
+++ b/includes/Shortcode/Stories_Shortcode.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Class Stories_Shortcode.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Shortcode;
+
+use Google\Web_Stories\Story_Query as Stories;
+
+/**
+ * Class Stories_Shortcode
+ *
+ * @package Google\Web_Stories\Shortcode
+ */
+class Stories_Shortcode {
+
+	/**
+	 * Shortcode attributes.
+	 *
+	 * @var array
+	 */
+	private $attributes;
+
+	/**
+	 * Shortcode name.
+	 *
+	 * @var string
+	 */
+	const SHORTCODE_NAME = 'stories';
+
+	/**
+	 * Initializes the Stories shortcode.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_shortcode( self::SHORTCODE_NAME, [ $this, 'render_stories' ] );
+	}
+
+	/**
+	 * Callback for the shortcode.
+	 *
+	 * This will render the stories according to given
+	 * shortcode attributes.
+	 *
+	 * @param array $attributes Shortcode attributes.
+	 *
+	 * @return string Story markup.
+	 */
+	public function render_stories( array $attributes ) {
+		$this->attributes = shortcode_atts(
+			[
+				'view'                      => 'circles',
+				'columns'                   => 2,
+				'title'                     => 'false',
+				'author'                    => 'false',
+				'date'                      => 'false',
+				'story_poster'              => 'true',
+				'archive_link'              => 'false',
+				'archive_label'             => __( 'View all stories', 'web-stories' ),
+				'list_view_image_alignment' => 'left',
+				'class'                     => '',
+				'number'                    => 10,
+				'order'                     => 'DESC',
+			],
+			$attributes
+		);
+
+		$stories = new Stories( $this->prepare_story_attrs(), $this->prepare_story_args() );
+
+		return $stories->render();
+	}
+
+	/**
+	 * Prepare story attributes.
+	 *
+	 * @return array Attributes to pass to Story_Query class.
+	 */
+	private function prepare_story_attrs() {
+		$attrs = [];
+
+		$attrs['view_type']                 = (string) $this->attributes['view'];
+		$attrs['number_of_columns']         = (int) $this->attributes['columns'];
+		$attrs['show_title']                = (bool) 'true' === $this->attributes['title'];
+		$attrs['show_author']               = (bool) 'true' === $this->attributes['author'];
+		$attrs['show_date']                 = (bool) 'true' === $this->attributes['date'];
+		$attrs['show_story_poster']         = (bool) 'true' === $this->attributes['story_poster'];
+		$attrs['show_story_archive_link']   = (bool) 'true' === $this->attributes['archive_link'];
+		$attrs['show_story_archive_label']  = (bool) 'true' === $this->attributes['archive_label'];
+		$attrs['list_view_image_alignment'] = (string) $this->attributes['list_view_image_alignment'];
+		$attrs['class']                     = (string) $this->attributes['class'];
+
+		return $attrs;
+	}
+
+	/**
+	 * Prepare story arguments.
+	 *
+	 * @return array Array of story arguments to pass to Story_Query.
+	 */
+	private function prepare_story_args() {
+		$args = [];
+
+		// Show 100 stories at most to avoid 500 errors.
+		$args['posts_per_page'] = min( (int) $this->attributes['number'], 100 );
+		$args['order']          = 'ASC' === $this->attributes['order'] ? 'ASC' : 'DESC';
+
+		return $args;
+	}
+}

--- a/includes/Shortcode/Stories_Shortcode.php
+++ b/includes/Shortcode/Stories_Shortcode.php
@@ -125,6 +125,25 @@ class Stories_Shortcode {
 		// Show 100 stories at most to avoid 500 errors.
 		$args['posts_per_page'] = min( (int) $this->attributes['number'], 100 );
 		$args['order']          = 'ASC' === $this->attributes['order'] ? 'ASC' : 'DESC';
+		$order_by               = $args['order'];
+
+		switch ( $order_by ) {
+			case 'oldest':
+				$args['order'] = 'ASC';
+				break;
+			case 'alphabetical':
+				$args['orderby'] = 'title';
+				$args['order']   = 'ASC';
+				break;
+			case 'reverse-alphabetical':
+				$args['orderby'] = 'title';
+				$args['order']   = 'DESC';
+				break;
+			case 'random':
+				$args['orderby'] = 'rand'; //phpcs:ignore WordPressVIPMinimum.Performance.OrderByRand.orderby_orderby
+				$args['order']   = 'DESC';
+				break;
+		}
 
 		return $args;
 	}

--- a/includes/Shortcode/Stories_Shortcode.php
+++ b/includes/Shortcode/Stories_Shortcode.php
@@ -82,7 +82,7 @@ class Stories_Shortcode {
 				'list_view_image_alignment' => 'left',
 				'class'                     => '',
 				'number'                    => 10,
-				'order'                     => 'DESC',
+				'order'                     => 'latest',
 			],
 			$attributes
 		);
@@ -124,8 +124,7 @@ class Stories_Shortcode {
 
 		// Show 100 stories at most to avoid 500 errors.
 		$args['posts_per_page'] = min( (int) $this->attributes['number'], 100 );
-		$args['order']          = 'ASC' === $this->attributes['order'] ? 'ASC' : 'DESC';
-		$order_by               = $args['order'];
+		$order_by               = $this->attributes['order'];
 
 		switch ( $order_by ) {
 			case 'oldest':

--- a/includes/Shortcode/Stories_Shortcode.php
+++ b/includes/Shortcode/Stories_Shortcode.php
@@ -102,12 +102,12 @@ class Stories_Shortcode {
 
 		$attrs['view_type']                 = (string) $this->attributes['view'];
 		$attrs['number_of_columns']         = (int) $this->attributes['columns'];
-		$attrs['show_title']                = (bool) 'true' === $this->attributes['title'];
-		$attrs['show_author']               = (bool) 'true' === $this->attributes['author'];
-		$attrs['show_date']                 = (bool) 'true' === $this->attributes['date'];
-		$attrs['show_story_poster']         = (bool) 'true' === $this->attributes['story_poster'];
-		$attrs['show_story_archive_link']   = (bool) 'true' === $this->attributes['archive_link'];
-		$attrs['show_story_archive_label']  = (bool) 'true' === $this->attributes['archive_label'];
+		$attrs['show_title']                = (bool) ( 'true' === $this->attributes['title'] );
+		$attrs['show_author']               = (bool) ( 'true' === $this->attributes['author'] );
+		$attrs['show_date']                 = (bool) ( 'true' === $this->attributes['date'] );
+		$attrs['show_story_poster']         = (bool) ( 'true' === $this->attributes['story_poster'] );
+		$attrs['show_story_archive_link']   = (bool) ( 'true' === $this->attributes['archive_link'] );
+		$attrs['show_story_archive_label']  = (bool) ( 'true' === $this->attributes['archive_label'] );
 		$attrs['list_view_image_alignment'] = (string) $this->attributes['list_view_image_alignment'];
 		$attrs['class']                     = (string) $this->attributes['class'];
 

--- a/includes/Stories_Renderer/Carousel_Renderer.php
+++ b/includes/Stories_Renderer/Carousel_Renderer.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Carousel_Renderer class.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Stories_Renderer;
+
+/**
+ * Carousel_Renderer class.
+ *
+ * Note: This class is useful to render stories in carousel view type.
+ * Do not instantiate this class directly, pass `view_type` argument
+ * to `Story_Query` which will handle the instantiation of the class.
+ */
+class Carousel_Renderer extends Renderer {
+
+	/**
+	 * Perform initial setup for object.
+	 *
+	 * @return void
+	 */
+	public function init() {
+
+		parent::init();
+
+		$this->assets();
+	}
+
+	/**
+	 * Enqueue assets.
+	 *
+	 * @return void
+	 */
+	public function assets() {
+
+		parent::assets();
+
+		if ( ! $this->is_amp_request() ) {
+			// Enqueue amp runtime script and amp-carousel script to show amp-carousel on non AMP pages.
+			wp_register_script( 'amp-runtime-script', 'https://cdn.ampproject.org/v0.js', [], 'v0', true );
+			wp_register_script( 'amp-carousel-script', 'https://cdn.ampproject.org/v0/amp-carousel-0.2.js', [ 'amp-runtime-script' ], 'v0', true );
+			wp_enqueue_script( 'amp-carousel-script' );
+		}
+	}
+
+	/**
+	 * Renders the stories output for given attributes.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+	 *
+	 * @return string Rendered stories output.
+	 */
+	public function render() {
+
+		if ( ! $this->valid() ) {
+			return '';
+		}
+
+		$container_classes = $this->get_container_classes();
+		$container_style   = $this->get_container_styles();
+
+		ob_start();
+		?>
+		<div>
+			<div
+				class="<?php echo esc_attr( $container_classes ); ?>"
+				style="<?php echo esc_attr( $container_style ); ?>"
+			>
+				<amp-carousel
+					width="1"
+					height="1"
+					layout="intrinsic"
+					type="carousel"
+					role="region"
+					aria-label="<?php esc_attr_e( 'Basic carousel', 'web-stories' ); ?>"
+				>
+					<?php
+					foreach ( $this->story_posts as $story ) {
+						$this->render_single_story_content();
+						$this->next();
+					}
+					?>
+				</amp-carousel>
+			</div>
+			<?php $this->maybe_render_archive_link(); ?>
+		</div>
+		<?php
+		$content = (string) ob_get_clean();
+
+		/**
+		 * Filters the Carousel renderer stories content.
+		 *
+		 * @param string $content Stories content.
+		 */
+		return apply_filters( 'web_stories_carousel_renderer_stories_content', $content );
+	}
+
+}

--- a/includes/Stories_Renderer/Generic_Renderer.php
+++ b/includes/Stories_Renderer/Generic_Renderer.php
@@ -105,6 +105,7 @@ class Generic_Renderer extends Renderer {
 		</div>
 		<?php
 		$view_type = $this->get_view_type();
+		$content   = (string) ob_get_clean();
 
 		/**
 		 * Filters the Generic renderer stories content.
@@ -113,7 +114,7 @@ class Generic_Renderer extends Renderer {
 		 *
 		 * @param string $content Stories content.
 		 */
-		return apply_filters( "web_stories_{$view_type}_renderer_stories_content", (string) ob_get_clean() );
+		return apply_filters( "web_stories_{$view_type}_renderer_stories_content", $content );
 	}
 
 }

--- a/includes/Stories_Renderer/Generic_Renderer.php
+++ b/includes/Stories_Renderer/Generic_Renderer.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Generic_Renderer class.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Stories_Renderer;
+
+use Google\Web_Stories\Embed_Base;
+
+/**
+ * Generic_Renderer class.
+ *
+ * This is named as `Generic` as this renderer class
+ * will be used to output multiple view types, like:
+ *
+ * 1. Circle
+ * 2. Grid
+ * 3. List
+ *
+ * Since, markup for all these views type is similar, Generic Renderer
+ * can be used to render the stories.
+ */
+class Generic_Renderer extends Renderer {
+
+	/**
+	 * Perform initial setup for object.
+	 *
+	 * @return void
+	 */
+	public function init() {
+
+		parent::init();
+
+		$this->assets();
+	}
+
+	/**
+	 * Enqueue assets.
+	 *
+	 * @return void
+	 */
+	public function assets() {
+
+		parent::assets();
+
+		if ( $this->is_view_type( 'grid' ) && ! $this->is_amp_request() && true !== $this->attributes['show_story_poster'] ) {
+			$this->enqueue_style( Embed_Base::STORY_PLAYER_HANDLE );
+			$this->enqueue_script( Embed_Base::STORY_PLAYER_HANDLE );
+		}
+	}
+
+	/**
+	 * Renders the stories output for given attributes.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+	 *
+	 * @return string Rendered stories output.
+	 */
+	public function render() {
+
+		if ( ! $this->valid() ) {
+			return '';
+		}
+
+		$container_classes = $this->get_container_classes();
+		$container_style   = $this->get_container_styles();
+
+		ob_start();
+		?>
+		<div>
+			<div
+				class="<?php echo esc_attr( $container_classes ); ?>"
+				style="<?php echo esc_attr( $container_style ); ?>"
+			>
+				<?php
+				foreach ( $this->story_posts as $story ) {
+					$this->render_single_story_content();
+					$this->next();
+				}
+				?>
+
+			</div>
+			<?php $this->maybe_render_archive_link(); ?>
+		</div>
+		<?php
+		$view_type = $this->get_view_type();
+
+		/**
+		 * Filters the Generic renderer stories content.
+		 *
+		 * The dynamic portion of the hook `$this->get_view_type()` refers to the story view type.
+		 *
+		 * @param string $content Stories content.
+		 */
+		return apply_filters( "web_stories_{$view_type}_renderer_stories_content", (string) ob_get_clean() );
+	}
+
+}

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -94,6 +94,13 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	protected $width = '285';
 
 	/**
+	 * Whether content overlay is enabled for story.
+	 *
+	 * @var bool
+	 */
+	protected $content_overlay;
+
+	/**
 	 * Constructor
 	 *
 	 * @param Stories $stories Stories instance.
@@ -220,11 +227,11 @@ abstract class Renderer implements RenderingInterface, Iterator {
 
 			if ( true === $this->attributes['show_title'] ) {
 				$story_title = get_the_title( $story_id );
+			}
 
-				if ( ! $is_circles_view ) {
-					$author_name = get_the_author_meta( 'display_name', $author_id );
-					$story_date  = get_the_date( 'M j, Y', $story_id );
-				}
+			if ( ! $is_circles_view ) {
+				$author_name = ( true === $this->attributes['show_author'] ) ? get_the_author_meta( 'display_name', $author_id ) : $author_name;
+				$story_date  = ( true === $this->attributes['show_date'] ) ? get_the_date( 'M j, Y', $story_id ) : $story_date;
 			}
 
 			$story_data['id']              = $story_id;
@@ -462,13 +469,13 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	protected function get_content_overlay() {
 		$story_data = $this->current();
 
-		if ( empty( $story_data->get_content_overlay() ) ) {
+		if ( empty( $this->content_overlay ) ) {
 			return;
 		}
 
 		?>
 		<div class="story-content-overlay web-stories-list__story-content-overlay">
-			<?php if ( ! empty( $story_data->get_title() ) ) { ?>
+			<?php if ( $this->attributes['show_title'] ) { ?>
 				<div class="story-content-overlay__title">
 					<?php
 					echo esc_html( $story_data->get_title() );

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -80,6 +80,20 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	private $position = 0;
 
 	/**
+	 * Height for displaying story.
+	 *
+	 * @var string
+	 */
+	protected $height = '430';
+
+	/**
+	 * Width for displaying story.
+	 *
+	 * @var string
+	 */
+	protected $width = '285';
+
+	/**
 	 * Constructor
 	 *
 	 * @param Stories $stories Stories instance.
@@ -214,8 +228,6 @@ abstract class Renderer implements RenderingInterface, Iterator {
 			}
 
 			$story_data['id']              = $story_id;
-			$story_data['height']          = '430';
-			$story_data['width']           = '285';
 			$story_data['author']          = $author_name;
 			$story_data['date']            = $story_date;
 			$story_data['classes']         = $this->get_single_story_classes();
@@ -378,8 +390,8 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	protected function render_story_with_poster() {
 
 		$story_data                = $this->current();
-		$height                    = ( ! empty( $story_data->get_height() ) ) ? absint( $story_data->get_height() ) : 600;
-		$width                     = ( ! empty( $story_data->get_width() ) ) ? absint( $story_data->get_width() ) : 360;
+		$height                    = ( ! empty( $this->height ) ) ? absint( $this->height ) : 600;
+		$width                     = ( ! empty( $this->width ) ) ? absint( $this->width ) : 360;
 		$poster_url                = ( 'circles' === $this->get_view_type() ) ? $story_data->get_poster_square() : $story_data->get_poster_portrait();
 		$poster_style              = sprintf( 'background-image: url(%1$s);', esc_url_raw( $poster_url ) );
 		$list_view_image_alignment = '';
@@ -414,8 +426,8 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	protected function render_story_with_story_player() {
 
 		$story_data              = $this->current();
-		$height                  = ( ! empty( $story_data->get_height() ) ) ? absint( $story_data->get_height() ) : 600;
-		$width                   = ( ! empty( $story_data->get_width() ) ) ? absint( $story_data->get_width() ) : 360;
+		$height                  = ( ! empty( $this->height ) ) ? absint( $this->height ) : 600;
+		$width                   = ( ! empty( $this->width ) ) ? absint( $this->width ) : 360;
 		$player_style            = sprintf( 'width: %1$spx;height: %2$spx', $width, $height );
 		$story_player_attributes = '';
 		$poster_image_url        = ( 'circles' === $this->get_view_type() ) ? $story_data->get_poster_square() : $story_data->get_poster_portrait();

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -234,14 +234,16 @@ abstract class Renderer implements RenderingInterface, Iterator {
 				$story_date  = ( true === $this->attributes['show_date'] ) ? get_the_date( 'M j, Y', $story_id ) : $story_date;
 			}
 
-			$story_data['id']              = $story_id;
-			$story_data['author']          = $author_name;
-			$story_data['date']            = $story_date;
-			$story_data['classes']         = $this->get_single_story_classes();
-			$story_data['content_overlay'] = ( ! empty( $story_title ) || ! empty( $author_name ) || ! empty( $story_date ) );
-			$transformed_post              = new Story( $story_data );
+			$story_data['id']      = $story_id;
+			$story_data['author']  = $author_name;
+			$story_data['date']    = $story_date;
+			$story_data['classes'] = $this->get_single_story_classes();
+			$transformed_post      = new Story( $story_data );
 			$transformed_post->load_from_post( $story_id );
 			$transformed_posts[] = $transformed_post;
+
+			$this->content_overlay = ( ! empty( $story_title ) || ! empty( $author_name ) || ! empty( $story_date ) );
+
 		}
 
 		return $transformed_posts;

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -1,0 +1,493 @@
+<?php
+/**
+ * Stories Renderer Base class.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Stories_Renderer;
+
+use Google\Web_Stories\Interfaces\Renderer as RenderingInterface;
+use Google\Web_Stories\Model\Story;
+use Google\Web_Stories\Story_Query as Stories;
+use Google\Web_Stories\Story_Post_Type;
+use Google\Web_Stories\Traits\Assets;
+use Iterator;
+
+/**
+ * Renderer class.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @implements Iterator<int, \WP_Post>
+ */
+abstract class Renderer implements RenderingInterface, Iterator {
+
+	use Assets;
+
+	/**
+	 * Web Stories stylesheet handle.
+	 *
+	 * @var string
+	 */
+	const STYLE_HANDLE = 'web-stories-list-styles';
+
+	/**
+	 * Stories object
+	 *
+	 * @var Stories Stories object
+	 */
+	protected $stories;
+
+	/**
+	 * Story attributes
+	 *
+	 * @var array An array of story attributes.
+	 */
+	protected $attributes = [];
+
+	/**
+	 * Story posts.
+	 *
+	 * @var array An array of story posts.
+	 */
+	protected $story_posts = [];
+
+	/**
+	 * Pointer to iterate over stories.
+	 *
+	 * @var int
+	 */
+	private $position = 0;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Stories $stories Stories instance.
+	 */
+	public function __construct( Stories $stories ) {
+
+		$this->stories    = $stories;
+		$this->attributes = $this->stories->get_story_attributes();
+	}
+
+	/**
+	 * Output markup for amp stories.
+	 *
+	 * @return string
+	 */
+	abstract public function render();
+
+	/**
+	 * Retrieve current story.
+	 *
+	 * @return mixed|void
+	 */
+	public function current() {
+		return $this->story_posts[ $this->position ];
+	}
+
+	/**
+	 * Retrieve next story.
+	 *
+	 * @retrun void
+	 */
+	public function next() {
+		++ $this->position;
+	}
+
+	/**
+	 * Retrieve the key for current node in list.
+	 *
+	 * @return bool|float|int|string|void|null
+	 */
+	public function key() {
+		return $this->position;
+	}
+
+	/**
+	 * Check if current position is valid.
+	 *
+	 * @return bool|void
+	 */
+	public function valid() {
+		return isset( $this->story_posts[ $this->position ] );
+	}
+
+	/**
+	 * Reset pointer to start of the list.
+	 *
+	 * @return void
+	 */
+	public function rewind() {
+		$this->position = 0;
+	}
+
+	/**
+	 * Perform initial setup for object.
+	 *
+	 * @return void
+	 */
+	public function init() {
+
+		add_filter( 'web_stories_get_stories_posts', [ $this, 'prepare_story_modal' ] );
+		$this->story_posts = $this->stories->get_stories();
+		remove_filter( 'web_stories_get_stories_posts', [ $this, 'prepare_story_modal' ] );
+	}
+
+	/**
+	 * Initializes renderer functionality.
+	 *
+	 * @return void
+	 */
+	public function assets() {
+
+		wp_enqueue_style(
+			self::STYLE_HANDLE,
+			WEBSTORIES_PLUGIN_DIR_URL . 'includes/assets/stories.css',
+			[],
+			WEBSTORIES_VERSION
+		);
+	}
+
+	/**
+	 * Determine whether the current request is for an AMP page.
+	 *
+	 * @return boolean
+	 */
+	public function is_amp_request() {
+
+		return ( amp_is_request() || is_amp_endpoint() );
+	}
+
+	/**
+	 * Returns story item data.
+	 *
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 *
+	 * @param array $posts Array of stories.
+	 *
+	 * @return array Returns single story item data.
+	 */
+	public function prepare_story_modal( array $posts ) {
+		if ( ! $posts ) {
+			return $posts;
+		}
+
+		$transformed_posts = [];
+		$is_circles_view   = $this->is_view_type( 'circles' );
+
+		foreach ( $posts as $a_post ) {
+			$story_title = '';
+			$author_name = '';
+			$story_date  = '';
+			$story_data  = [];
+			$story_id    = $a_post->ID;
+			$author_id   = absint( get_post_field( 'post_author', $story_id ) );
+
+			if ( true === $this->attributes['show_title'] ) {
+				$story_title = get_the_title( $story_id );
+
+				if ( ! $is_circles_view ) {
+					$author_name = get_the_author_meta( 'display_name', $author_id );
+					$story_date  = get_the_date( 'M j, Y', $story_id );
+				}
+			}
+
+			$story_data['id']              = $story_id;
+			$story_data['height']          = '430';
+			$story_data['width']           = '285';
+			$story_data['author']          = $author_name;
+			$story_data['date']            = $story_date;
+			$story_data['classes']         = $this->get_single_story_classes();
+			$story_data['content_overlay'] = ( ! empty( $story_title ) || ! empty( $author_name ) || ! empty( $story_date ) );
+			$transformed_post              = new Story( $story_data );
+			$transformed_post->load_from_post( $story_id );
+			$transformed_posts[] = $transformed_post;
+		}
+
+		return $transformed_posts;
+	}
+
+	/**
+	 * Verifies the current view type.
+	 *
+	 * @param string $view_type View type to check.
+	 *
+	 * @return bool Whether or not current view type matches the one passed.
+	 */
+	protected function is_view_type( $view_type ) {
+
+		return ( ! empty( $this->attributes['view_type'] ) && $view_type === $this->attributes['view_type'] );
+	}
+
+	/**
+	 * Get view type for stories.
+	 *
+	 * @return string
+	 */
+	protected function get_view_type() {
+
+		return ( ! empty( $this->attributes['view_type'] ) ) ? $this->attributes['view_type'] : 'circles';
+	}
+
+	/**
+	 * Renders stories archive link if the 'show_stories_archive_link' attribute is set to true.
+	 *
+	 * @return void
+	 */
+	protected function maybe_render_archive_link() {
+
+		if ( empty( $this->attributes['show_stories_archive_link'] ) || true !== $this->attributes['show_stories_archive_link'] ) {
+			return;
+		}
+
+		$web_stories_archive = get_post_type_archive_link( Story_Post_Type::POST_TYPE_SLUG );
+
+		if ( empty( $web_stories_archive ) || ! is_string( $web_stories_archive ) ) {
+			return;
+		}
+
+		?>
+		<div class="web-stories-list__archive-link">
+			<a href="<?php echo esc_url( $web_stories_archive ); ?>">
+				<?php echo esc_html( $this->attributes['stories_archive_label'] ); ?>
+			</a>
+		</div>
+		<?php
+
+	}
+
+	/**
+	 * Gets the classes for renderer container.
+	 *
+	 * @return string
+	 */
+	protected function get_container_classes() {
+
+		$container_classes   = [];
+		$container_classes[] = 'web-stories-list';
+		$container_classes[] = ( ! empty( $this->attributes['view_type'] ) ) ? sprintf( 'is-view-type-%1$s', $this->attributes['view_type'] ) : 'is-view-type-circles';
+		$container_classes[] = ( ! empty( $this->attributes['align'] ) ) ? sprintf( 'align%1$s', $this->attributes['align'] ) : 'alignnone';
+		$container_classes[] = ( ! empty( $this->attributes['class'] ) ) ? $this->attributes['class'] : '';
+
+		$container_classes = array_filter( $container_classes );
+
+		return implode( ' ', $container_classes );
+	}
+
+	/**
+	 * Gets the single story container classes.
+	 *
+	 * @return string
+	 */
+	protected function get_single_story_classes() {
+
+		$single_story_classes   = [];
+		$single_story_classes[] = 'web-stories-list__story-wrapper';
+
+		if ( ! $this->is_view_type( 'grid' ) ) {
+			$single_story_classes[] = 'has-poster';
+		}
+
+		if ( $this->is_view_type( 'grid' ) && true === $this->attributes['show_story_poster'] ) {
+			$single_story_classes[] = 'has-poster';
+		}
+
+		$single_story_classes = array_filter( $single_story_classes );
+		$classes              = implode( ' ', $single_story_classes );
+
+		/**
+		 * Filters the web stories renderer single story classes.
+		 *
+		 * @param string $class Single story classes.
+		 */
+		return apply_filters( 'web_stories_renderer_single_story_classes', $classes );
+	}
+
+	/**
+	 * Gets the container style attributes.
+	 *
+	 * @return string
+	 */
+	protected function get_container_styles() {
+
+		$container_style = '';
+
+		if ( true === $this->is_view_type( 'grid' ) ) {
+			$container_style = sprintf( 'grid-template-columns:repeat(%1$s, 1fr);', $this->attributes['number_of_columns'] );
+		}
+
+		/**
+		 * Filters the web stories renderer container style.
+		 *
+		 * @param string $class Container style.
+		 */
+		return apply_filters( 'web_stories_renderer_container_style', $container_style );
+	}
+
+	/**
+	 * Render story markup.
+	 *
+	 * @return void
+	 */
+	public function render_single_story_content() {
+		$single_story_classes = $this->get_single_story_classes();
+		$show_story_player    = ( true !== $this->attributes['show_story_poster'] && $this->is_view_type( 'grid' ) );
+
+		?>
+
+		<div class="<?php echo esc_attr( $single_story_classes ); ?>">
+			<?php
+
+			if ( true === $show_story_player ) {
+				$this->render_story_with_story_player();
+			} else {
+				$this->render_story_with_poster();
+			}
+			?>
+		</div>
+		<?php
+
+	}
+
+	/**
+	 * Renders a story with story's poster image.
+	 *
+	 * @return void
+	 */
+	protected function render_story_with_poster() {
+
+		$story_data                = $this->current();
+		$height                    = ( ! empty( $story_data->get_height() ) ) ? absint( $story_data->get_height() ) : 600;
+		$width                     = ( ! empty( $story_data->get_width() ) ) ? absint( $story_data->get_width() ) : 360;
+		$poster_url                = ( 'circles' === $this->get_view_type() ) ? $story_data->get_poster_square() : $story_data->get_poster_portrait();
+		$poster_style              = sprintf( 'background-image: url(%1$s);', esc_url_raw( $poster_url ) );
+		$list_view_image_alignment = '';
+
+		if ( true === $this->is_view_type( 'carousel' ) ) {
+			$poster_style = sprintf( '%1$s width: %2$spx; height: %3$spx', $poster_style, $width, $height );
+		}
+
+		if ( ! empty( $this->attributes['list_view_image_alignment'] ) ) {
+			$list_view_image_alignment = sprintf( 'image-align-%1$s', $this->attributes['list_view_image_alignment'] );
+		}
+
+		?>
+		<a class="<?php echo esc_attr( $list_view_image_alignment ); ?>"
+			href="<?php echo esc_url( $story_data->get_url() ); ?>"
+		>
+			<div
+				class="web-stories-list__story-placeholder"
+				style="<?php echo esc_attr( $poster_style ); ?>"
+			></div>
+			<?php $this->get_content_overlay(); ?>
+		</a>
+		<?php
+
+	}
+
+	/**
+	 * Renders a story with amp-story-player.
+	 *
+	 * @return void
+	 */
+	protected function render_story_with_story_player() {
+
+		$story_data              = $this->current();
+		$height                  = ( ! empty( $story_data->get_height() ) ) ? absint( $story_data->get_height() ) : 600;
+		$width                   = ( ! empty( $story_data->get_width() ) ) ? absint( $story_data->get_width() ) : 360;
+		$player_style            = sprintf( 'width: %1$spx;height: %2$spx', $width, $height );
+		$story_player_attributes = '';
+		$poster_image_url        = ( 'circles' === $this->get_view_type() ) ? $story_data->get_poster_square() : $story_data->get_poster_portrait();
+		$poster_style            = '';
+
+		if ( $this->is_amp_request() ) {
+			$story_player_attributes = sprintf( 'height=%d width=%d', $height, $width );
+		}
+
+		if ( ! empty( $poster_image_url ) ) {
+			$poster_style = sprintf( '--story-player-poster: url(%s)', $poster_image_url );
+		}
+
+		?>
+		<amp-story-player style="<?php echo esc_attr( $player_style ); ?>"
+			<?php echo( esc_attr( $story_player_attributes ) ); ?>>
+			<a href="<?php echo esc_url( $story_data->get_url() ); ?>" style="<?php echo esc_attr( $poster_style ); ?>">
+				<?php echo esc_html( $story_data->get_title() ); ?>
+			</a>
+		</amp-story-player>
+
+		<?php
+
+		$this->get_content_overlay();
+	}
+
+	/**
+	 * Renders the content overlay markup.
+	 *
+	 * @return void
+	 */
+	protected function get_content_overlay() {
+		$story_data = $this->current();
+
+		if ( empty( $story_data->get_content_overlay() ) ) {
+			return;
+		}
+
+		?>
+		<div class="story-content-overlay web-stories-list__story-content-overlay">
+			<?php if ( ! empty( $story_data->get_title() ) ) { ?>
+				<div class="story-content-overlay__title">
+					<?php
+					echo esc_html( $story_data->get_title() );
+					?>
+				</div>
+			<?php } ?>
+
+			<div class="story-content-overlay__author-date">
+				<?php if ( ! empty( $story_data->get_author() ) ) { ?>
+					<div>
+						<?php
+
+						/* translators: %s: author name. */
+						echo esc_html( sprintf( __( 'By %s', 'web-stories' ), $story_data->get_author() ) );
+						?>
+					</div>
+				<?php } ?>
+
+				<?php if ( ! empty( $story_data->get_date() ) ) { ?>
+					<time class="story-content-overlay__date">
+						<?php
+
+						/* translators: %s: publish date. */
+						echo esc_html( sprintf( __( 'On %s', 'web-stories' ), $story_data->get_date() ) );
+						?>
+					</time>
+				<?php } ?>
+			</div>
+		</div>
+		<?php
+
+	}
+
+}

--- a/includes/Story_Query.php
+++ b/includes/Story_Query.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Stories class.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories;
+
+use Google\Web_Stories\Stories_Renderer\Carousel_Renderer;
+use Google\Web_Stories\Stories_Renderer\Generic_Renderer;
+use Google\Web_Stories\Stories_Renderer\Renderer;
+use WP_Query;
+
+/**
+ * Stories class.
+ */
+class Story_Query {
+
+	/**
+	 * Story attributes
+	 *
+	 * @var array An array of story attributes.
+	 */
+	protected $story_attributes = [];
+
+	/**
+	 * Story query arguments.
+	 *
+	 * @var array An array of query arguments.
+	 */
+	protected $query_arguments = [];
+
+	/**
+	 * Renderer object.
+	 *
+	 * @var Renderer
+	 */
+	public $renderer;
+
+	/**
+	 * Class constructor
+	 *
+	 * @param array $story_attributes          {
+	 *                                         An array of story attributes.
+	 *
+	 *     @type string $view_type                 Stories View type. Default circles.
+	 *     @type int    $number_of_columns         Number of columns to show in grid view. Default 2.
+	 *     @type bool   $show_title                Whether to show story title or not. Default false.
+	 *     @type bool   $show_author               Whether to show story author or not. Default false.
+	 *     @type bool   $show_date                 Whether to show story date or not. Default false.
+	 *     @type bool   $show_story_poster         Whether to show story story poster or show story player. Default true.
+	 *     @type bool   $show_stories_archive_link Whether to show view all link or not. Default false.
+	 *     @type string $stories_archive_label     The label for view all link. Default 'View all stories'.
+	 *     @type string $list_view_image_alignment The list mode image alignment. Default 'left'.
+	 *     @type string $class                     Additional CSS classes for the container. Default empty string.
+	 * }
+	 * @param array $query_arguments           An array of query arguments for story. @see WP_Query::parse_query() for
+	 *                                         all available arguments.
+	 */
+	public function __construct( array $story_attributes = [], array $query_arguments = [] ) {
+
+		$this->story_attributes = $story_attributes;
+		$this->query_arguments  = $query_arguments;
+	}
+
+	/**
+	 * Retrieves an array of the latest stories, or Stories matching the given criteria.
+	 *
+	 * @return array An array of Story posts.
+	 */
+	public function get_stories() {
+
+		$query_args    = $this->get_query_args();
+		$stories_query = new WP_Query( $query_args );
+		$posts         = ( ! empty( $stories_query->posts ) && is_array( $stories_query->posts ) ) ? $stories_query->posts : [];
+
+		/**
+		 * Filter the stories posts.
+		 *
+		 * @param array $posts Array of stories' posts.
+		 */
+		return apply_filters( 'web_stories_get_stories_posts', $posts );
+	}
+
+	/**
+	 * Instantiates the renderer classes based on the view type.
+	 *
+	 * @return Renderer Renderer Instance.
+	 */
+	private function get_renderer() {
+
+		$story_attributes = $this->get_story_attributes();
+		$view_type        = ( ! empty( $story_attributes['view_type'] ) ) ? $story_attributes['view_type'] : '';
+
+		switch ( $view_type ) {
+			case 'carousel':
+				$renderer = new Carousel_Renderer( $this );
+				break;
+
+			case 'circles':
+			case 'list':
+			case 'grid':
+			default:
+				$renderer = new Generic_Renderer( $this );
+		}
+
+		$renderer->init();
+
+		return $renderer;
+	}
+
+	/**
+	 * Renders the stories output.
+	 *
+	 * @return string
+	 */
+	public function render() {
+
+		$this->renderer = $this->get_renderer();
+
+		return $this->renderer->render();
+	}
+
+	/**
+	 * Gets an array of story attributes.
+	 *
+	 * @return array An array of story attributes.
+	 */
+	public function get_story_attributes() {
+
+		$default_attributes = [
+			'view_type'                 => 'circles',
+			'number_of_columns'         => 2,
+			'show_title'                => false,
+			'show_author'               => false,
+			'show_date'                 => false,
+			'show_story_poster'         => true,
+			'show_stories_archive_link' => false,
+			'stories_archive_label'     => __( 'View all stories', 'web-stories' ),
+			'list_view_image_alignment' => 'left',
+			'class'                     => '',
+		];
+
+		return wp_parse_args( $this->story_attributes, $default_attributes );
+	}
+
+	/**
+	 * Returns arguments to be passed to the WP_Query object initialization.
+	 *
+	 * @return array An array of query arguments.
+	 */
+	protected function get_query_args() {
+
+		$default_query_args = [
+			'post_type'        => Story_Post_Type::POST_TYPE_SLUG,
+			'posts_per_page'   => 10,
+			'post_status'      => 'publish',
+			'suppress_filters' => false,
+			'no_found_rows'    => true,
+		];
+
+		return wp_parse_args( $this->query_arguments, $default_query_args );
+	}
+
+}

--- a/includes/assets/stories.css
+++ b/includes/assets/stories.css
@@ -1,0 +1,142 @@
+/*
+ * Generic styles that apply to all view modes
+ */
+.web-stories-list .web-stories-list__story-wrapper a {
+  color: #555555;
+  text-decoration: none;
+  font-size: 16px;
+}
+
+.web-stories-list .web-stories-list__story-wrapper {
+  max-width: 285px;
+  position: relative;
+}
+
+.web-stories-list amp-story-player,
+.web-stories-list .web-stories-list__story-wrapper.has-poster {
+  width: 100%;
+  max-width: 285px;
+  height: auto;
+}
+
+.web-stories-list .web-stories-list__story-placeholder {
+  background-size: cover;
+  background-position: center;
+  height: 430px;
+}
+
+/* story content overlay styles */
+.web-stories-list .story-content-overlay {
+  position: absolute;
+  z-index: 1;
+  bottom: 10px;
+  left: 10px;
+  right: 10px;
+  background-color: #ffffff;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.2);
+  padding: 20px;
+  color: #555555;
+  font-size: 12px;
+  line-height: 16px;
+  letter-spacing: 0.2px;
+}
+
+.web-stories-list .story-content-overlay__author-date {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+}
+
+.web-stories-list .story-content-overlay__title {
+  grid-column: 1/-1;
+  font-size: 15px;
+  line-height: 22px;
+  font-weight: 700;
+}
+
+/* Grid View Styles */
+.web-stories-list.is-view-type-grid {
+  display: grid;
+  grid-gap: 32px;
+}
+
+.web-stories-list.is-view-type-grid .web-stories-list__story-wrapper {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* List View Styles */
+.web-stories-list.is-view-type-list .story-content-overlay {
+  position: relative;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.web-stories-list.is-view-type-list .web-stories-list__story-wrapper {
+  max-width: unset;
+  margin-bottom: 24px;
+}
+
+.web-stories-list.is-view-type-list .web-stories-list__story-wrapper > * {
+  display: flex;
+}
+
+.web-stories-list.is-view-type-list .image-align-right {
+  flex-direction: row-reverse;
+}
+
+.web-stories-list.is-view-type-list .web-stories-list__story-placeholder {
+  height: auto;
+  flex-basis: 40%;
+  padding-top: 17%;
+  flex-shrink: 0;
+}
+
+/* Circles View Styles */
+.web-stories-list.is-view-type-circles {
+  display: flex;
+  overflow-x: scroll;
+  padding: 5px;
+}
+
+.web-stories-list.is-view-type-circles .story-content-overlay {
+  position: unset;
+  background-color: transparent;
+  box-shadow: unset;
+  padding: 10px 0;
+  text-align: center;
+}
+
+.web-stories-list.is-view-type-circles .story-content-overlay__title {
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.web-stories-list.is-view-type-circles .web-stories-list__story-wrapper {
+  margin-right: 32px;
+  flex-shrink: 0;
+  max-width: 150px;
+}
+
+.web-stories-list.is-view-type-circles .web-stories-list__story-placeholder {
+  height: 150px;
+  width: 150px;
+  border-radius: 50%;
+  background-clip: content-box;
+  border: 3px solid #666;
+  padding: 2px;
+}
+
+.web-stories-list.is-view-type-circles
+  .web-stories-list__story-placeholder:hover {
+  border-color: #333;
+}
+
+/* Stories archive link styles */
+.web-stories-list__archive-link {
+  margin-top: 16px;
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -42,7 +42,6 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	require dirname( dirname( __DIR__ ) ) . '/includes/compat/amp.php';
 	require dirname( dirname( __DIR__ ) ) . '/web-stories.php';
 }
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -42,6 +42,7 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
+	require dirname( dirname( __DIR__ ) ) . '/includes/compat/amp.php';
 	require dirname( dirname( __DIR__ ) ) . '/web-stories.php';
 }
 

--- a/tests/phpunit/includes/Test_Renderer.php
+++ b/tests/phpunit/includes/Test_Renderer.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Test_Renderer class.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests;
+
+use Google\Web_Stories\Stories_Renderer\Renderer;
+
+/**
+ * Generic_Renderer class.
+ */
+class Test_Renderer extends Renderer {
+
+	/**
+	 * Render method
+	 *
+	 * @return void
+	 */
+	public function render() {}
+
+}

--- a/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
+++ b/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Stories_Shortcode Unit Test class.
+ *
+ * @package   Google\Web_Stories\Tests
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests\Shortcode;
+
+use Google\Web_Stories\Shortcode\Stories_Shortcode as Testee;
+use Google\Web_Stories\Story_Post_Type;
+
+/**
+ * @coversDefaultClass \Google\Web_Stories\Shortcode\Stories_Shortcode
+ */
+class Stories_Shortcode extends \WP_UnitTestCase {
+
+	/**
+	 * Story ID.
+	 *
+	 * @var int
+	 */
+	private static $story_id;
+
+	/**
+	 * Run before any test is run and class is being setup.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$story_id = $factory->post->create(
+			[
+				'post_type'   => Story_Post_Type::POST_TYPE_SLUG,
+				'post_status' => 'publish',
+				'post_title'  => 'Test Story',
+			]
+		);
+	}
+
+	/**
+	 * Runs after all tests are run.
+	 */
+	public function tearDown() {
+		remove_shortcode( Testee::SHORTCODE_NAME );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers ::render_stories
+	 * @covers ::prepare_story_args
+	 * @covers ::prepare_story_attrs
+	 */
+	public function test_render_carousel_view_in_shortcode() {
+		$stories_shortcode = new Testee();
+		$actual = $stories_shortcode->render_stories(
+			[
+				'view' => 'carousel',
+			]
+		);
+
+		$this->assertTrue( false !== strpos( $actual, '<amp-carousel' ) );
+	}
+}

--- a/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
+++ b/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
@@ -48,6 +48,8 @@ class Stories_Shortcode extends \WP_UnitTestCase {
 	 * Run before any test is run and class is being setup.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
+		require dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/includes/compat/amp.php';
+
 		self::$story_id = $factory->post->create(
 			[
 				'post_type'   => Story_Post_Type::POST_TYPE_SLUG,
@@ -73,7 +75,7 @@ class Stories_Shortcode extends \WP_UnitTestCase {
 	 */
 	public function test_render_carousel_view_in_shortcode() {
 		$stories_shortcode = new Testee();
-		$actual = $stories_shortcode->render_stories(
+		$actual            = $stories_shortcode->render_stories(
 			[
 				'view' => 'carousel',
 			]
@@ -88,8 +90,8 @@ class Stories_Shortcode extends \WP_UnitTestCase {
 	 * @covers ::prepare_story_args
 	 */
 	public function test_render_circles_view_in_shortcode() {
-		$stories_Shortcode = new Testee();
-		$actual = $stories_Shortcode->render_stories(
+		$stories_shortcode = new Testee();
+		$actual            = $stories_shortcode->render_stories(
 			[
 				'view' => 'circles',
 			]
@@ -121,17 +123,17 @@ class Stories_Shortcode extends \WP_UnitTestCase {
 	 * @covers ::prepare_story_args
 	 */
 	public function test_max_number_for_stories() {
-		$stories_Shortcode = new Testee();
+		$stories_shortcode = new Testee();
 		$this->set_private_property(
-			$stories_Shortcode,
+			$stories_shortcode,
 			'attributes',
 			[
 				'number' => 1000000,
-				'order'  => 'DESC'
+				'order'  => 'DESC',
 			]
 		);
 
-		$args = $this->call_private_method( $stories_Shortcode, 'prepare_story_args' );
+		$args = $this->call_private_method( $stories_shortcode, 'prepare_story_args' );
 		$this->assertSame( 100, $args['posts_per_page'] );
 	}
 }

--- a/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
+++ b/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
@@ -28,11 +28,14 @@ namespace Google\Web_Stories\Tests\Shortcode;
 
 use Google\Web_Stories\Shortcode\Stories_Shortcode as Testee;
 use Google\Web_Stories\Story_Post_Type;
+use Google\Web_Stories\Tests\Private_Access;
 
 /**
  * @coversDefaultClass \Google\Web_Stories\Shortcode\Stories_Shortcode
  */
 class Stories_Shortcode extends \WP_UnitTestCase {
+
+	use Private_Access;
 
 	/**
 	 * Story ID.
@@ -77,5 +80,58 @@ class Stories_Shortcode extends \WP_UnitTestCase {
 		);
 
 		$this->assertTrue( false !== strpos( $actual, '<amp-carousel' ) );
+	}
+
+	/**
+	 * @covers ::render_stories
+	 * @covers ::prepare_story_attrs
+	 * @covers ::prepare_story_args
+	 */
+	public function test_render_circles_view_in_shortcode() {
+		$stories_Shortcode = new Testee();
+		$actual = $stories_Shortcode->render_stories(
+			[
+				'view' => 'circles',
+			]
+		);
+
+		$this->assertTrue( false !== strpos( $actual, '<div class="web-stories-list__story-wrapper has-poster">' ) );
+	}
+
+	/**
+	 * Test story player while using shortcode.
+	 *
+	 * @covers ::render_stories
+	 */
+	public function test_render_story_player_in_shortcode() {
+		$stories_shortcode = new Testee();
+		$actual            = $stories_shortcode->render_stories(
+			[
+				'story_poster' => 'false',
+				'view'         => 'grid',
+			]
+		);
+
+		$this->assertTrue( false !== strpos( $actual, '<amp-story-player' ) );
+	}
+
+	/**
+	 * Stories should not be greater than 100.
+	 *
+	 * @covers ::prepare_story_args
+	 */
+	public function test_max_number_for_stories() {
+		$stories_Shortcode = new Testee();
+		$this->set_private_property(
+			$stories_Shortcode,
+			'attributes',
+			[
+				'number' => 1000000,
+				'order'  => 'DESC'
+			]
+		);
+
+		$args = $this->call_private_method( $stories_Shortcode, 'prepare_story_args' );
+		$this->assertSame( 100, $args['posts_per_page'] );
 	}
 }

--- a/tests/phpunit/tests/Stories.php
+++ b/tests/phpunit/tests/Stories.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests;
+
+use Google\Web_Stories\Story_Query as Testee;
+use Google\Web_Stories\Stories_Renderer\Generic_Renderer;
+use Google\Web_Stories\Story_Post_Type;
+
+/**
+ * @coversDefaultClass \Google\Web_Stories\Stories
+ */
+class Stories extends \WP_UnitTestCase {
+
+	/**
+	 * Class in test.
+	 *
+	 * @var Testee
+	 */
+	private static $testee;
+
+	/**
+	 * Story ID.
+	 *
+	 * @var int
+	 */
+	private static $story_id;
+
+	/**
+	 * Default story arguments.
+	 *
+	 * @var array
+	 */
+	private static $default_story_args;
+
+	/**
+	 * Default query arguments.
+	 *
+	 * @var array
+	 */
+	private static $default_query_args;
+
+	/**
+	 * Runs once before any test in the class run.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Factory class object.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+
+		self::$testee = new Testee();
+
+		self::$story_id = $factory->post->create(
+			[
+				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'   => 'Example title',
+				'post_status'  => 'publish',
+				'post_content' => 'Example content',
+			]
+		);
+
+		self::$default_story_args = [
+			'view_type'                 => 'circles',
+			'number_of_columns'         => 2,
+			'show_title'                => false,
+			'show_author'               => false,
+			'show_date'                 => false,
+			'show_story_poster'         => true,
+			'show_stories_archive_link' => false,
+			'stories_archive_label'     => 'View all stories',
+			'list_view_image_alignment' => 'left',
+			'class'                     => '',
+		];
+
+		self::$default_query_args = [
+			'post_type'        => Story_Post_Type::POST_TYPE_SLUG,
+			'posts_per_page'   => 10,
+			'post_status'      => 'publish',
+			'suppress_filters' => false,
+			'no_found_rows'    => true,
+		];
+
+	}
+
+	/**
+	 * Test that instance of
+	 *
+	 * @covers ::render
+	 */
+	public function test_render() {
+		$output = get_echo( [ self::$testee, 'render' ] );
+
+		$this->assertInstanceOf( Generic_Renderer::class, self::$testee->renderer );
+	}
+
+	/**
+	 * Test that get_stories method returns valid story.
+	 *
+	 * @covers ::get_stories
+	 */
+	public function test_get_stories_returns_valid_story() {
+
+		$story_posts = self::$testee->get_stories();
+		$this->assertSame( self::$story_id, $story_posts[0]->ID );
+	}
+
+	/**
+	 * Test that get_stories method returns valid story.
+	 *
+	 * @covers ::get_stories
+	 */
+	public function test_get_stories_returns_empty_array() {
+
+		$stories_obj = new Testee( [], [ 'post_type' => 'draft' ] );
+		$story_posts = $stories_obj->get_stories();
+		$this->assertEmpty( $story_posts );
+	}
+
+	/**
+	 * Test story arguments are equal.
+	 *
+	 * @covers ::get_story_attributes
+	 */
+	public function test_default_story_args_equality() {
+
+		$story_args = self::$testee->get_story_attributes();
+		$this->assertSame( self::$default_story_args, $story_args );
+	}
+
+}

--- a/tests/phpunit/tests/Stories_Renderer/Carousel_Renderer.php
+++ b/tests/phpunit/tests/Stories_Renderer/Carousel_Renderer.php
@@ -70,10 +70,6 @@ class Carousel_Renderer extends \WP_UnitTestCase_Base {
 	public function setUp() {
 
 		$this->story_model = $this->createMock( Story::class );
-
-		$this->story_model->method( 'get_height' )->willReturn( 430 );
-		$this->story_model->method( 'get_width' )->willReturn( 630 );
-
 		$this->stories     = $this->createMock( Stories::class );
 		$this->stories->method( 'get_stories' )->willReturn( [ $this->story_model ] );
 		$this->story_posts = [ get_post( self::$story_id ) ];

--- a/tests/phpunit/tests/Stories_Renderer/Carousel_Renderer.php
+++ b/tests/phpunit/tests/Stories_Renderer/Carousel_Renderer.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests\Stories_Renderer;
+
+use Google\Web_Stories\Model\Story;
+use Google\Web_Stories\Story_Query as Stories;
+
+/**
+ * @coversDefaultClass \Google\Web_Stories\Stories_Renderer\Carousel_Renderer
+ */
+class Carousel_Renderer extends \WP_UnitTestCase_Base {
+
+	/**
+	 * Stories mock object.
+	 *
+	 * @var Stories
+	 */
+	private $stories;
+
+	/**
+	 * Story post ID.
+	 *
+	 * @var int
+	 */
+	private static $story_id;
+
+	/**
+	 * Story Modal.
+	 *
+	 * @var Story
+	 */
+	private $story_model;
+
+	/**
+	 * Runs once before any test in the class run.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Factory class object.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+
+		self::$story_id = $factory->post->create(
+			[
+				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'   => 'Example title',
+				'post_status'  => 'publish',
+				'post_content' => 'Example content',
+			]
+		);
+
+	}
+
+	/**
+	 * Runs once before any test in the class run.
+	 */
+	public function setUp() {
+
+		$this->story_model = $this->createMock( Story::class );
+
+		$this->story_model->method( 'get_height' )->willReturn( 430 );
+		$this->story_model->method( 'get_width' )->willReturn( 630 );
+
+		$this->stories     = $this->createMock( Stories::class );
+		$this->stories->method( 'get_stories' )->willReturn( [ $this->story_model ] );
+		$this->story_posts = [ get_post( self::$story_id ) ];
+	}
+
+	/**
+	 * @covers ::init
+	 * @covers ::assets
+	 */
+	public function test_init() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'view_type' => 'carousel',
+			]
+		);
+
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Carousel_Renderer( $this->stories );
+		$renderer->init();
+
+		$this->assertTrue( wp_script_is( 'amp-carousel-script', 'registered' ) );
+		$this->assertTrue( wp_script_is( 'amp-runtime-script', 'registered' ) );
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function test_render() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'view_type'                 => 'carousel',
+				'show_title'                => false,
+				'show_author'               => false,
+				'show_date'                 => false,
+				'show_story_poster'         => false,
+				'show_stories_archive_link' => false,
+				'stories_archive_label'     => 'View all stories',
+				'class'                     => '',
+			]
+		);
+
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Carousel_Renderer( $this->stories );
+
+		$renderer->init();
+
+		$output = $renderer->render();
+
+		$this->assertContains( 'amp-carousel', $output );
+		$this->assertContains( 'web-stories-list is-view-type-carousel alignnone', $output );
+		$this->assertContains( 'web-stories-list__story-wrapper has-poster', $output );
+		$this->assertContains( 'web-stories-list__story-placeholder', $output );
+
+	}
+
+}

--- a/tests/phpunit/tests/Stories_Renderer/Generic_Renderer.php
+++ b/tests/phpunit/tests/Stories_Renderer/Generic_Renderer.php
@@ -69,11 +69,7 @@ class Generic_Renderer extends \WP_UnitTestCase_Base {
 	 */
 	public function setUp() {
 		$this->story_model = $this->createMock( Story::class );
-
-		$this->story_model->method( 'get_height' )->willReturn( 430 );
-		$this->story_model->method( 'get_width' )->willReturn( 630 );
-
-		$this->stories = $this->createMock( Stories::class );
+		$this->stories     = $this->createMock( Stories::class );
 		$this->stories->method( 'get_stories' )->willReturn( [ $this->story_model ] );
 	}
 

--- a/tests/phpunit/tests/Stories_Renderer/Generic_Renderer.php
+++ b/tests/phpunit/tests/Stories_Renderer/Generic_Renderer.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests\Stories_Renderer;
+
+use Google\Web_Stories\Model\Story;
+use Google\Web_Stories\Story_Query as Stories;
+
+/**
+ * @coversDefaultClass \Google\Web_Stories\Stories_Renderer\Generic_Renderer
+ */
+class Generic_Renderer extends \WP_UnitTestCase_Base {
+
+	/**
+	 * Stories mock object.
+	 *
+	 * @var Stories
+	 */
+	private $stories;
+
+	/**
+	 * Story post ID.
+	 *
+	 * @var int
+	 */
+	private static $story_id;
+
+	/**
+	 * Story model.
+	 *
+	 * @var Story
+	 */
+	private $story_model;
+
+	/**
+	 * Runs once before any test in the class run.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Factory class object.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+
+		self::$story_id = $factory->post->create(
+			[
+				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'   => 'Example title',
+				'post_status'  => 'publish',
+				'post_content' => 'Example content',
+			]
+		);
+
+	}
+
+	/**
+	 * Runs once before any test in the class run.
+	 */
+	public function setUp() {
+		$this->story_model = $this->createMock( Story::class );
+
+		$this->story_model->method( 'get_height' )->willReturn( 430 );
+		$this->story_model->method( 'get_width' )->willReturn( 630 );
+
+		$this->stories = $this->createMock( Stories::class );
+		$this->stories->method( 'get_stories' )->willReturn( [ $this->story_model ] );
+	}
+
+	/**
+	 * @covers ::assets
+	 */
+	public function test_assets() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'class'             => '',
+				'view_type'         => 'grid',
+				'show_story_poster' => false,
+			]
+		);
+
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Generic_Renderer( $this->stories );
+		$renderer->init();
+
+		$this->assertTrue( wp_style_is( \Google\Web_Stories\Embed_Base::STORY_PLAYER_HANDLE ) );
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function test_render() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'view_type'                 => 'grid',
+				'number_of_columns'         => 2,
+				'show_title'                => false,
+				'show_author'               => false,
+				'show_date'                 => false,
+				'show_story_poster'         => true,
+				'show_stories_archive_link' => false,
+				'stories_archive_label'     => 'View all stories',
+				'list_view_image_alignment' => 'left',
+				'class'                     => '',
+			]
+		);
+
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Generic_Renderer( $this->stories );
+		$renderer->init();
+
+		$output = $renderer->render();
+
+		$this->assertContains( 'web-stories-list is-view-type-grid alignnone', $output );
+		$this->assertContains( 'web-stories-list__story-wrapper has-poster', $output );
+		$this->assertContains( 'web-stories-list__story-placeholder', $output );
+
+	}
+
+}

--- a/tests/phpunit/tests/Stories_Renderer/Renderer.php
+++ b/tests/phpunit/tests/Stories_Renderer/Renderer.php
@@ -83,9 +83,6 @@ class Renderer extends \WP_UnitTestCase_Base {
 	public function setUp() {
 		$this->story_model = $this->createMock( Story::class );
 
-		$this->story_model->method( 'get_height' )->willReturn( 430 );
-		$this->story_model->method( 'get_width' )->willReturn( 630 );
-
 		$this->stories = $this->createMock( Stories::class );
 		$this->stories->method( 'get_stories' )->willReturn( [ $this->story_model ] );
 	}

--- a/tests/phpunit/tests/Stories_Renderer/Renderer.php
+++ b/tests/phpunit/tests/Stories_Renderer/Renderer.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Generic_Renderer class.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests\Stories_Renderer;
+
+use Google\Web_Stories\Model\Story;
+use Google\Web_Stories\Tests\Test_Renderer;
+use Google\Web_Stories\Story_Query as Stories;
+use Google\Web_Stories\Tests\Private_Access;
+use Google\Web_Stories\Stories_Renderer\Renderer as AbstractRenderer;
+
+/**
+ * Generic_Renderer class.
+ *
+ * @coversDefaultClass \Google\Web_Stories\Stories_Renderer\Renderer
+ */
+class Renderer extends \WP_UnitTestCase_Base {
+
+	use Private_Access;
+
+	/**
+	 * Story post ID.
+	 *
+	 * @var int
+	 */
+	private static $story_id;
+
+	/**
+	 * Stories mock object.
+	 *
+	 * @var Stories
+	 */
+	private $stories;
+
+	/**
+	 * Story Model Mock.
+	 *
+	 * @var Story
+	 */
+	private $story_model;
+
+	/**
+	 * Runs once before any test in the class run.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Factory class object.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+
+		self::$story_id = $factory->post->create(
+			[
+				'post_type' => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+			]
+		);
+
+	}
+
+	/**
+	 * Runs once before any test in the class run.
+	 */
+	public function setUp() {
+		$this->story_model = $this->createMock( Story::class );
+
+		$this->story_model->method( 'get_height' )->willReturn( 430 );
+		$this->story_model->method( 'get_width' )->willReturn( 630 );
+
+		$this->stories = $this->createMock( Stories::class );
+		$this->stories->method( 'get_stories' )->willReturn( [ $this->story_model ] );
+	}
+
+	/**
+	 * @covers ::assets
+	 */
+	public function test_assets() {
+
+		$renderer = new Test_Renderer( $this->stories );
+
+		$renderer->assets();
+
+		$this->assertTrue( wp_style_is( \Google\Web_Stories\Stories_Renderer\Renderer::STYLE_HANDLE ) );
+	}
+
+	/**
+	 * @covers ::is_view_type
+	 */
+	public function test_is_view_type() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'view_type' => 'grid',
+			]
+		);
+		$renderer = new Test_Renderer( $this->stories );
+
+		$output = $this->call_private_method( $renderer, 'is_view_type', [ 'grid' ] );
+
+		$this->assertTrue( $output );
+
+		$output = $this->call_private_method( $renderer, 'is_view_type', [ 'list' ] );
+
+		$this->assertFalse( $output );
+	}
+
+	/**
+	 * @covers ::get_view_type
+	 */
+	public function test_get_view_type() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'view_type' => 'grid',
+			]
+		);
+		$renderer = new Test_Renderer( $this->stories );
+
+		$output = $this->call_private_method( $renderer, 'get_view_type' );
+
+		$this->assertEquals( 'grid', $output );
+
+	}
+
+	/**
+	 * @covers ::render_story_with_story_player
+	 */
+	public function test_render_story_with_story_player() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'view_type'         => 'grid',
+				'class'             => '',
+				'show_story_poster' => false,
+			]
+		);
+
+		$renderer = $this->getMockForAbstractClass( AbstractRenderer::class, [ $this->stories ] );
+		$renderer->method( 'is_amp_request' )->willReturn( false );
+		$this->set_private_property( $renderer, 'story_posts', [ $this->stories->get_stories() ] );
+
+		ob_start();
+		$this->call_private_method( $renderer, 'render_story_with_story_player' );
+		$output = ob_get_clean();
+
+		$this->assertContains( '<amp-story-player style="width: 285px;height: 430px"', $output );
+		$this->assertContains( '--story-player-poster: url(www.example.com/image.jpg)', $output );
+		$this->assertContains( 'Story Title', $output );
+	}
+
+	/**
+	 * @covers ::render_story_with_poster
+	 */
+	public function test_render_story_with_poster() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'view_type'                 => 'list',
+				'class'                     => '',
+				'show_story_poster'         => true,
+				'list_view_image_alignment' => 'left',
+			]
+		);
+
+		$renderer = $this->getMockForAbstractClass( AbstractRenderer::class, [ $this->stories ] );
+		$renderer->expects( $this->once() )->method( 'is_amp_request' )->willReturn( false );
+		$this->set_private_property( $renderer, 'story_posts', [ $this->stories->get_stories() ] );
+
+		ob_start();
+		$this->call_private_method( $renderer, 'render_story_with_poster' );
+		$output = ob_get_clean();
+
+		$this->assertContains( 'web-stories-list__story-placeholder', $output );
+		$this->assertContains( 'style="background-image: url(http://www.example.com/image.jpg);"', $output );
+	}
+
+	/**
+	 * @covers ::get_content_overlay
+	 */
+	public function test_get_content_overlay() {
+
+		$renderer = $this->getMockForAbstractClass( AbstractRenderer::class, [ $this->stories ] );
+		$renderer->method( 'is_amp_request' )->willReturn( false );
+		$this->set_private_property( $renderer, 'story_posts', [ $this->stories->get_stories() ] );
+
+		ob_start();
+		$this->call_private_method( $renderer, 'get_content_overlay' );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+
+		$story_data = [
+			'title'                => 'Story Title',
+			'date'                 => 'November 11, 2020',
+			'author'               => 'admin',
+			'show_content_overlay' => true,
+		];
+
+		ob_start();
+		$this->call_private_method( $renderer, 'get_content_overlay', [ $story_data ] );
+		$output = ob_get_clean();
+
+		$this->assertContains( 'By admin', $output );
+		$this->assertContains( 'On November 11, 2020', $output );
+		$this->assertContains( 'Story Title', $output );
+	}
+
+	/**
+	 * @covers ::get_container_styles
+	 */
+	public function test_get_container_styles() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'view_type'         => 'grid',
+				'number_of_columns' => '3',
+			]
+		);
+
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Generic_Renderer( $this->stories );
+
+		$expected = 'grid-template-columns:repeat(3, 1fr);';
+		$output   = $this->call_private_method( $renderer, 'get_container_styles' );
+
+		$this->assertEquals( $expected, $output );
+	}
+
+	/**
+	 * @covers ::get_single_story_classes
+	 */
+	public function test_get_single_story_classes() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'show_story_poster' => true,
+				'view_type'         => 'circles',
+			]
+		);
+
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Generic_Renderer( $this->stories );
+		$expected = 'web-stories-list__story-wrapper has-poster';
+
+		$output = $this->call_private_method( $renderer, 'get_single_story_classes' );
+
+		$this->assertEquals( $expected, $output );
+	}
+
+	/**
+	 * @covers ::get_container_classes
+	 */
+	public function test_get_container_classes() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'view_type'         => 'circles',
+				'class'             => 'test',
+				'show_story_poster' => false,
+			]
+		);
+
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Generic_Renderer( $this->stories );
+
+		$expected = 'web-stories-list is-view-type-circles alignnone test';
+
+		$output = $this->call_private_method( $renderer, 'get_container_classes' );
+
+		$this->assertEquals( $expected, $output );
+	}
+
+	/**
+	 * @covers ::maybe_render_archive_link
+	 */
+	public function test_maybe_render_archive_link() {
+
+		$this->stories->method( 'get_story_attributes' )->willReturn(
+			[
+				'show_story_poster'         => false,
+				'show_stories_archive_link' => true,
+				'stories_archive_label'     => 'View All Stories',
+			]
+		);
+
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Generic_Renderer( $this->stories );
+
+		$archive_link = get_post_type_archive_link( \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG );
+		ob_start();
+		$this->call_private_method( $renderer, 'maybe_render_archive_link' );
+		$expected = ob_get_clean();
+
+		$this->assertContains( 'web-stories-list__archive-link', $expected );
+		$this->assertContains( $archive_link, $expected );
+		$this->assertContains( 'View All Stories', $expected );
+
+	}
+}


### PR DESCRIPTION
### Create a stories shortcode API in order to embed stories within shortcode blocks and classic editor.

#### Usage

1. Insert this shortcode in either Shortcode Block or Classic Editor.
2. Save the Post and Visit it on Frontend.

```php
[stories view="circles" number="2" class="my-stories-wrapper" /]
```

#### Result

![screenshot-content local-2020 11 27-13_52_30](https://user-images.githubusercontent.com/1442637/100427103-f2778680-30b7-11eb-8853-d9a7619b0f7c.png)

#### Shortcode Attributes.

1.  `view`: View type for the stories. Example: circles, grid, list etc.
2.  `columns`: Number of columns for the stories.
3.  `title`: Whether to show title in the stories.
4.  `author`: Whether to show author name in the stories.
5.  `date`: Whether to display date in the stories.
6.  `story_poster`: Whether to show story poster.
7.  `archive_link`: Whether to display stories archive link.
8.  `archive_label`: Label for archive label.
9.  `list_view_image_alignment`: Useful in List mode. Alignment for image in list mode.
10. `class`: Classes for the stories wrapper.
11. `number`: How many number of stories to display. Max: 100
12. `order`: Order for rendering stories. Stories are rendered based on their publish timing. Possible options are `ASC`/`DESC`