### PR TITLE
Lightbox: Performance enhancement

### DIFF
--- a/includes/assets/index.js
+++ b/includes/assets/index.js
@@ -1,0 +1,5 @@
+import initializeWebStoryLightbox from './web-stories-lightbox';
+
+window.addEventListener('load', () => {
+  initializeWebStoryLightbox();
+});

--- a/includes/assets/index.js
+++ b/includes/assets/index.js
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
 import initializeWebStoryLightbox from './web-stories-lightbox';
 
 window.addEventListener('load', () => {

--- a/includes/assets/latest-stories.css
+++ b/includes/assets/latest-stories.css
@@ -250,7 +250,7 @@
 }
 
 /* Lightbox styles */
-.web-stories .web-stories__story-lightbox {
+.web-stories .web-stories__lightbox {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -266,7 +266,7 @@
   opacity: 0;
 }
 
-.web-stories .web-stories__story-lightbox.show {
+.web-stories .web-stories__lightbox.show {
   opacity: 1;
   visibility: visible;
 }
@@ -294,7 +294,7 @@
 }
 
 @media only screen and (max-width: 600px) {
-  .web-stories .web-stories__story-lightbox amp-story-player {
+  .web-stories .web-stories__lightbox amp-story-player {
     height: 100%;
     max-width: 100%;
   }

--- a/includes/assets/web-stories-lightbox.js
+++ b/includes/assets/web-stories-lightbox.js
@@ -1,0 +1,55 @@
+class Lightbox {
+	constructor( wrapperDiv ) {
+    if('undefined' === typeof wrapperDiv){
+      return;
+    }
+
+    this.wrapperDiv = wrapperDiv;
+    this.player = this.wrapperDiv.querySelector('amp-story-player');
+    this.lightboxElement = this.wrapperDiv.querySelector('.web-stories__lightbox');
+
+    if('undefined' === typeof this.player || 'undefined' === typeof this.lightboxElement) {
+      return;
+    }
+
+    if (this.player.isReady) {
+      this.initializeLightbox();
+    }
+
+    this.player.addEventListener('ready', () => {
+      this.initializeLightbox();
+    });
+
+    // Event triggered when user clicks on close (X) button.
+    this.player.addEventListener('amp-story-player-close', () => {
+      this.lightboxElement.classList.toggle('show');
+    });
+
+  }
+
+  initializeLightbox() {
+    this.stories = this.player.getStories();
+    this.bindStoryClickListeners();
+  }
+
+  bindStoryClickListeners() {
+    const cards = this.wrapperDiv.querySelectorAll('.web-stories__story-wrapper');
+
+    cards.forEach((card, index) => {
+      card.addEventListener('click', () => {
+        this.player.show(this.stories[index].href);
+        this.lightboxElement.classList.toggle('show');
+      });
+    });
+
+  }
+};
+
+export default function initializeWebStoryLightbox() {
+  const webStoryBlocks = document.getElementsByClassName('web-stories'); // Replace with our generic wrapper class name.
+  if('undefined' !== typeof webStoryBlocks){
+    Array.from(webStoryBlocks).forEach((webStoryBlock) => {
+      new Lightbox(webStoryBlock);
+    })
+  }
+}

--- a/includes/assets/web-stories-lightbox.js
+++ b/includes/assets/web-stories-lightbox.js
@@ -1,14 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 class Lightbox {
-	constructor( wrapperDiv ) {
-    if('undefined' === typeof wrapperDiv){
+  constructor(wrapperDiv) {
+    if ('undefined' === typeof wrapperDiv) {
       return;
     }
 
     this.wrapperDiv = wrapperDiv;
     this.player = this.wrapperDiv.querySelector('amp-story-player');
-    this.lightboxElement = this.wrapperDiv.querySelector('.web-stories__lightbox');
+    this.lightboxElement = this.wrapperDiv.querySelector(
+      '.web-stories__lightbox'
+    );
 
-    if('undefined' === typeof this.player || 'undefined' === typeof this.lightboxElement) {
+    if (
+      'undefined' === typeof this.player ||
+      'undefined' === typeof this.lightboxElement
+    ) {
       return;
     }
 
@@ -24,7 +44,6 @@ class Lightbox {
     this.player.addEventListener('amp-story-player-close', () => {
       this.lightboxElement.classList.toggle('show');
     });
-
   }
 
   initializeLightbox() {
@@ -33,7 +52,9 @@ class Lightbox {
   }
 
   bindStoryClickListeners() {
-    const cards = this.wrapperDiv.querySelectorAll('.web-stories__story-wrapper');
+    const cards = this.wrapperDiv.querySelectorAll(
+      '.web-stories__story-wrapper'
+    );
 
     cards.forEach((card, index) => {
       card.addEventListener('click', () => {
@@ -41,15 +62,14 @@ class Lightbox {
         this.lightboxElement.classList.toggle('show');
       });
     });
-
   }
-};
+}
 
 export default function initializeWebStoryLightbox() {
   const webStoryBlocks = document.getElementsByClassName('web-stories'); // Replace with our generic wrapper class name.
-  if('undefined' !== typeof webStoryBlocks){
+  if ('undefined' !== typeof webStoryBlocks) {
     Array.from(webStoryBlocks).forEach((webStoryBlock) => {
       new Lightbox(webStoryBlock);
-    })
+    });
   }
 }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -197,6 +197,39 @@ const dashboard = {
   },
 };
 
+const webStoriesScripts = {
+  ...sharedConfig,
+  entry: {
+    'web-stories-scripts': './includes/assets/index.js',
+  },
+  plugins: [
+    process.env.BUNDLE_ANALZYER && new BundleAnalyzerPlugin(),
+    new DependencyExtractionWebpackPlugin({
+      injectPolyfill: true,
+    }),
+    new MiniCssExtractPlugin({
+      filename: '../css/[name].css',
+    }),
+    new WebpackBar({
+      name: 'Web Stories Scripts',
+      color: '#357BB5',
+    }),
+  ].filter(Boolean),
+  optimization: {
+    ...sharedConfig.optimization,
+    splitChunks: {
+      cacheGroups: {
+        stories: {
+          name: 'web-stories-scripts',
+          test: /\.css$/,
+          chunks: 'all',
+          enforce: true,
+        },
+      },
+    },
+  },
+};
+
 const storyEmbedBlock = {
   ...sharedConfig,
   entry: {
@@ -327,6 +360,7 @@ const activationNotice = {
 module.exports = [
   storiesEditor,
   dashboard,
+  webStoriesScripts,
   storyEmbedBlock,
   latestStoriesBlock,
   selectedStoriesBlock,


### PR DESCRIPTION
## Summary
- Improves lightbox's performance on non-AMP pages. Check implementation details below under `Relevant Technical Choices`.
- Base branch: `feature/latest-stories` because we still don't have lightbox setup on new markup that was setup on `rt/gutenberg-blocks` branch. I didn't have enough bandwidth to make add lightbox on both AMP and non-AMP.

## Relevant Technical Choices
- Previously, we had separate lightbox for each story that is to be rendered. This results in loading all stories on page load even when none of them are actually visible to the end user.
- With these changes, we will end up with only one lightbox/amp-story-player (on non-AMP at least for now), which results in drastic decrease in page load time.
<!-- Please describe your changes. -->

## To-do
- The same implementation was to be applied for AMP version of the stories as well. However, the DOM element, `amp-story-player`, received in `<amp-script>` component does not contain any of the API methods that can be used to have this implemented in AMP version. I had a detailed discussion on this with Divyaraj and Edi.
- This PR makes no changes in the lightbox on AMP pages.

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #42 #79 
