### PR TITLE
PHP Stories API for Centralised Data Querying

### DIFF
--- a/includes/Interfaces/Renderer.php
+++ b/includes/Interfaces/Renderer.php
@@ -28,6 +28,8 @@
 
 namespace Google\Web_Stories\Interfaces;
 
+use Google\Web_Stories\Interfaces\FieldState;
+
 /**
  * Interface Renderer.
  *
@@ -58,4 +60,12 @@ interface Renderer {
 	 * @return mixed
 	 */
 	public function render_single_story_content();
+
+	/**
+	 * This should return the fields state
+	 * for the current view type.
+	 *
+	 * @return FieldState
+	 */
+	public function field();
 }

--- a/includes/Stories_Renderer/Carousel_Renderer.php
+++ b/includes/Stories_Renderer/Carousel_Renderer.php
@@ -96,7 +96,7 @@ class Carousel_Renderer extends Renderer {
 					layout="intrinsic"
 					type="carousel"
 					role="region"
-					aria-label="<?php esc_attr_e( 'Web Stories', 'web-stories' ); ?>"
+					aria-label="<?php esc_attr_e( 'Basic carousel', 'web-stories' ); ?>"
 				>
 					<?php
 					foreach ( $this->story_posts as $story ) {

--- a/includes/Stories_Renderer/Carousel_Renderer.php
+++ b/includes/Stories_Renderer/Carousel_Renderer.php
@@ -96,7 +96,7 @@ class Carousel_Renderer extends Renderer {
 					layout="intrinsic"
 					type="carousel"
 					role="region"
-					aria-label="<?php esc_attr_e( 'Basic carousel', 'web-stories' ); ?>"
+					aria-label="<?php esc_attr_e( 'Web Stories', 'web-stories' ); ?>"
 				>
 					<?php
 					foreach ( $this->story_posts as $story ) {

--- a/includes/Stories_Renderer/FieldState/BaseFieldState.php
+++ b/includes/Stories_Renderer/FieldState/BaseFieldState.php
@@ -112,6 +112,8 @@ abstract class BaseFieldState implements FieldState {
 	/**
 	 * Prepare a field object.
 	 *
+	 * @param array $args Arguments to build field.
+	 *
 	 * @return BaseField
 	 */
 	protected function prepare_field( array $args ) {

--- a/includes/Stories_Renderer/FieldState/BaseFieldState.php
+++ b/includes/Stories_Renderer/FieldState/BaseFieldState.php
@@ -21,7 +21,7 @@
  * limitations under the License.
  */
 
-namespace Google\Web_Stories\FieldState;
+namespace Google\Web_Stories\Stories_Renderer\FieldState;
 
 use Google\Web_Stories\Interfaces\Field;
 use Google\Web_Stories\Stories_Renderer\Fields\BaseField;

--- a/includes/Stories_Renderer/FieldState/CarouselView.php
+++ b/includes/Stories_Renderer/FieldState/CarouselView.php
@@ -75,7 +75,7 @@ class CarouselView extends BaseFieldState {
 		return $this->prepare_field(
 			[
 				'label'    => $label,
-				'show'     => false,
+				'show'     => true,
 				'readonly' => false,
 			]
 		);
@@ -92,7 +92,7 @@ class CarouselView extends BaseFieldState {
 		return $this->prepare_field(
 			[
 				'label'    => $label,
-				'show'     => false,
+				'show'     => true,
 				'readonly' => false,
 			]
 		);
@@ -109,7 +109,7 @@ class CarouselView extends BaseFieldState {
 		return $this->prepare_field(
 			[
 				'label'    => $label,
-				'show'     => false,
+				'show'     => true,
 				'readonly' => true,
 			]
 		);

--- a/includes/Stories_Renderer/FieldState/CarouselView.php
+++ b/includes/Stories_Renderer/FieldState/CarouselView.php
@@ -1,5 +1,11 @@
 <?php
 /**
+ * Carousel view based controls state.
+ *
+ * @package Google\Web_Stories
+ */
+
+/**
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/includes/Stories_Renderer/FieldState/CarouselView.php
+++ b/includes/Stories_Renderer/FieldState/CarouselView.php
@@ -23,7 +23,6 @@
 
 namespace Google\Web_Stories\Stories_Renderer\FieldState;
 
-use Google\Web_Stories\FieldState\BaseFieldState;
 use Google\Web_Stories\Stories_Renderer\Fields\BaseField;
 
 /**

--- a/includes/Stories_Renderer/FieldState/CircleView.php
+++ b/includes/Stories_Renderer/FieldState/CircleView.php
@@ -23,7 +23,6 @@
 
 namespace Google\Web_Stories\Stories_Renderer\FieldState;
 
-use Google\Web_Stories\FieldState\BaseFieldState;
 use Google\Web_Stories\Stories_Renderer\Fields\BaseField;
 
 /**

--- a/includes/Stories_Renderer/FieldState/CircleView.php
+++ b/includes/Stories_Renderer/FieldState/CircleView.php
@@ -1,5 +1,11 @@
 <?php
 /**
+ * Circle view based controls state.
+ *
+ * @package Google\Web_Stories
+ */
+
+/**
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/includes/Stories_Renderer/FieldState/GridView.php
+++ b/includes/Stories_Renderer/FieldState/GridView.php
@@ -1,5 +1,11 @@
 <?php
 /**
+ * Grid view based controls state.
+ *
+ * @package Google\Web_Stories
+ */
+
+/**
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/includes/Stories_Renderer/FieldState/GridView.php
+++ b/includes/Stories_Renderer/FieldState/GridView.php
@@ -23,7 +23,6 @@
 
 namespace Google\Web_Stories\Stories_Renderer\FieldState;
 
-use Google\Web_Stories\FieldState\BaseFieldState;
 use Google\Web_Stories\Stories_Renderer\Fields\BaseField;
 
 /**

--- a/includes/Stories_Renderer/FieldState/ListView.php
+++ b/includes/Stories_Renderer/FieldState/ListView.php
@@ -23,7 +23,6 @@
 
 namespace Google\Web_Stories\Stories_Renderer\FieldState;
 
-use Google\Web_Stories\FieldState\BaseFieldState;
 use Google\Web_Stories\Stories_Renderer\Fields\BaseField;
 
 /**

--- a/includes/Stories_Renderer/FieldState/ListView.php
+++ b/includes/Stories_Renderer/FieldState/ListView.php
@@ -1,5 +1,11 @@
 <?php
 /**
+ * List view based controls state.
+ *
+ * @package Google\Web_Stories
+ */
+
+/**
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/includes/Stories_Renderer/FieldState/ListView.php
+++ b/includes/Stories_Renderer/FieldState/ListView.php
@@ -109,7 +109,7 @@ class ListView extends BaseFieldState {
 		return $this->prepare_field(
 			[
 				'label'    => $label,
-				'show'     => false,
+				'show'     => true,
 				'readonly' => false,
 			]
 		);

--- a/includes/Stories_Renderer/Fields/BaseField.php
+++ b/includes/Stories_Renderer/Fields/BaseField.php
@@ -60,7 +60,7 @@ class BaseField implements Field {
 	public function __construct( array $args ) {
 		$this->label    = isset( $args['label'] ) ? $args['label'] : '';
 		$this->readonly = isset( $args['readonly'] ) ? (bool) $args['readonly'] : true;
-		$this->show     = true;
+		$this->show     = isset( $args['show'] ) ? (bool) $args['show'] : true;
 	}
 
 	/**

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -209,7 +209,17 @@ abstract class Renderer implements RenderingInterface, Iterator {
 				$field_state = new CarouselView();
 				break;
 			default:
-				$field_state = apply_filters( 'web_stories_default_fieldstate', new GridView() );
+				$default_field_state = new CircleView();
+				/**
+				 * Filters the fieldstate object.
+				 *
+				 * This depicts
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param FieldState $default_field_state Field states for circle view.
+				 */
+				$field_state = apply_filters( 'web_stories_default_fieldstate', $default_field_state );
 		}
 
 		return $field_state;

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -215,7 +215,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 				 *
 				 * This depicts
 				 *
-				 * @since 2.0.0
+				 * @since 1.3.0
 				 *
 				 * @param FieldState $default_field_state Field states for circle view.
 				 */

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -26,6 +26,7 @@
 
 namespace Google\Web_Stories\Stories_Renderer;
 
+use Google\Web_Stories\Interfaces\FieldState;
 use Google\Web_Stories\Interfaces\Renderer as RenderingInterface;
 use Google\Web_Stories\Model\Story;
 use Google\Web_Stories\Story_Query as Stories;
@@ -189,7 +190,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	/**
 	 * Return the fields state.
 	 *
-	 * @return \Google\Web_Stories\Interfaces\FieldState
+	 * @return FieldState
 	 */
 	public function field() {
 		$view = isset( $this->attributes['view_type'] ) ? $this->attributes['view_type'] : 'grid';

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -31,6 +31,10 @@ use Google\Web_Stories\Model\Story;
 use Google\Web_Stories\Story_Query as Stories;
 use Google\Web_Stories\Story_Post_Type;
 use Google\Web_Stories\Traits\Assets;
+use Google\Web_Stories\Stories_Renderer\FieldState\GridView;
+use Google\Web_Stories\Stories_Renderer\FieldState\ListView;
+use Google\Web_Stories\Stories_Renderer\FieldState\CarouselView;
+use Google\Web_Stories\Stories_Renderer\FieldState\CircleView;
 use Iterator;
 
 /**
@@ -180,6 +184,34 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 */
 	public function init() {
 		$this->story_posts = array_map( [ $this, 'prepare_story_modal' ], $this->stories->get_stories() );
+	}
+
+	/**
+	 * Return the fields state.
+	 *
+	 * @return \Google\Web_Stories\Interfaces\FieldState
+	 */
+	public function field() {
+		$view = isset( $this->attributes['view_type'] ) ? $this->attributes['view_type'] : 'grid';
+
+		switch ( $view ) {
+			case 'grid':
+				$field_state = new GridView();
+				break;
+			case 'list':
+				$field_state = new ListView();
+				break;
+			case 'circles':
+				$field_state = new CircleView();
+				break;
+			case 'carousel':
+				$field_state = new CarouselView();
+				break;
+			default:
+				$field_state = apply_filters( 'web_stories_default_fieldstate', new GridView() );
+		}
+
+		return $field_state;
 	}
 
 	/**

--- a/includes/Story_Query.php
+++ b/includes/Story_Query.php
@@ -102,7 +102,7 @@ class Story_Query {
 	 *
 	 * @return Renderer Renderer Instance.
 	 */
-	private function get_renderer() {
+	public function get_renderer() {
 
 		$story_attributes = $this->get_story_attributes();
 		$view_type        = ( ! empty( $story_attributes['view_type'] ) ) ? $story_attributes['view_type'] : '';

--- a/includes/Story_Query.php
+++ b/includes/Story_Query.php
@@ -154,6 +154,7 @@ class Story_Query {
 			'stories_archive_label'     => __( 'View all stories', 'web-stories' ),
 			'list_view_image_alignment' => 'left',
 			'class'                     => '',
+			'circle_size'               => 150,
 		];
 
 		return wp_parse_args( $this->story_attributes, $default_attributes );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Miscellaneous functions.
+ * These are mostly utility or wrapper functions.
+ *
+ * @package Google\Web_Stories
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use Google\Web_Stories\Customizer;
+
+if ( ! function_exists( 'web_stories_customizer' ) ) {
+	/**
+	 * Fetch stories based on customizer settings.
+	 *
+	 * @param bool $echo Whether to display the stories.
+	 *
+	 * @return string|void
+	 */
+	function web_stories_customizer( $echo = true ) {
+		$stories = Customizer::render_stories();
+
+		if ( ! $echo ) {
+			return $stories;
+		}
+
+		//phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $stories;
+	}
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -21,25 +21,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+namespace Google\Web_Stories;
 
-use Google\Web_Stories\Customizer;
-
-if ( ! function_exists( 'web_stories_customizer' ) ) {
-	/**
-	 * Fetch stories based on customizer settings.
-	 *
-	 * @param bool $echo Whether to display the stories.
-	 *
-	 * @return string|void
-	 */
-	function web_stories_customizer( $echo = true ) {
-		$stories = Customizer::render_stories();
-
-		if ( ! $echo ) {
-			return $stories;
-		}
-
-		//phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo $stories;
-	}
+/**
+ * Fetch stories based on customizer settings.
+ *
+ * @param array $args Arguments for fetching stories.
+ *
+ * @return string|void
+ */
+function stories( $args = [] ) {
+	$story_query = new Story_Query( $args );
+	echo $story_query->render();
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -32,5 +32,6 @@ namespace Google\Web_Stories;
  */
 function stories( $args = [] ) {
 	$story_query = new Story_Query( $args );
+	//phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo $story_query->render();
 }

--- a/tests/phpunit/tests/Stories_Renderer/Fields/BaseField.php
+++ b/tests/phpunit/tests/Stories_Renderer/Fields/BaseField.php
@@ -56,14 +56,14 @@ class BaseField extends \WP_UnitTestCase_Base {
 	 * @covers ::readonly
 	 */
 	public function test_readonly() {
-		$this->assertSame( true, self::$testee->readonly() );
+		$this->assertTrue( self::$testee->readonly() );
 	}
 
 	/**
 	 * @covers ::show
 	 */
 	public function test_show() {
-		$this->assertSame( true, self::$testee->show() );
+		$this->assertTrue( self::$testee->show() );
 	}
 }
 

--- a/tests/phpunit/tests/Stories_Renderer/Fields/BaseField.php
+++ b/tests/phpunit/tests/Stories_Renderer/Fields/BaseField.php
@@ -39,13 +39,6 @@ class BaseField extends \WP_UnitTestCase_Base {
 	}
 
 	/**
-	 * @covers ::__construct
-	 */
-	public function test_instance() {
-		$this->assertInstanceOf( Testee::class, self::$testee );
-	}
-
-	/**
 	 * @covers ::label
 	 */
 	public function test_label() {

--- a/tests/phpunit/tests/Stories_Renderer/Fields/BaseField.php
+++ b/tests/phpunit/tests/Stories_Renderer/Fields/BaseField.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * BaseField Class.
+ *
+ * @package Google\Web_Stories
+ */
+
+namespace Google\Web_Stories\Tests\Stories_Renderer\Fields;
+
+use PHPUnit\Framework\TestCase;
+use Google\Web_Stories\Stories_Renderer\Fields\BaseField as Testee;
+
+/**
+ * Class BaseField.
+ *
+ * @package Google\Web_Stories\Tests\Stories_Renderer\Fields
+ *
+ * @coversDefaultClass \Google\Web_Stories\Stories_Renderer\Fields\BaseField
+ */
+class BaseField extends \WP_UnitTestCase_Base {
+
+	/**
+	 * Object of class in test.
+	 *
+	 * @var Testee
+	 */
+	private static $testee;
+
+	/**
+	 * Runs before any test in class is executed.
+	 */
+	public static function wpSetUpBeforeClass() {
+		self::$testee = new Testee(
+			[
+				'label'    => 'Test Label',
+				'readonly' => true,
+			]
+		);
+	}
+
+	/**
+	 * @covers ::__construct
+	 */
+	public function test_instance() {
+		$this->assertInstanceOf( Testee::class, self::$testee );
+	}
+
+	/**
+	 * @covers ::label
+	 */
+	public function test_label() {
+		$this->assertSame( 'Test Label', self::$testee->label() );
+	}
+
+	/**
+	 * @covers ::readonly
+	 */
+	public function test_readonly() {
+		$this->assertSame( true, self::$testee->readonly() );
+	}
+
+	/**
+	 * @covers ::show
+	 */
+	public function test_show() {
+		$this->assertSame( true, self::$testee->show() );
+	}
+}
+

--- a/tests/phpunit/tests/Story_Query.php
+++ b/tests/phpunit/tests/Story_Query.php
@@ -1,5 +1,14 @@
 <?php
 /**
+ * Stories class.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,64 +24,126 @@
  * limitations under the License.
  */
 
-namespace Google\Web_Stories\Tests;
+namespace Google\Web_Stories;
 
-use Google\Web_Stories\Story_Query as Testee;
+use Google\Web_Stories\Stories_Renderer\Carousel_Renderer;
 use Google\Web_Stories\Stories_Renderer\Generic_Renderer;
-use Google\Web_Stories\Story_Post_Type as Story_CPT;
+use Google\Web_Stories\Stories_Renderer\Renderer;
+use WP_Query;
 
 /**
- * @coversDefaultClass \Google\Web_Stories\Story_Query
+ * Stories class.
  */
-class Story_Query extends \WP_UnitTestCase {
+class Story_Query {
 
 	/**
-	 * Class in test.
+	 * Story attributes
 	 *
-	 * @var Testee
+	 * @var array An array of story attributes.
 	 */
-	private static $testee;
+	protected $story_attributes = [];
 
 	/**
-	 * Story ID.
+	 * Story query arguments.
 	 *
-	 * @var int
+	 * @var array An array of query arguments.
 	 */
-	private static $story_id;
+	protected $query_arguments = [];
 
 	/**
-	 * Default story arguments.
+	 * Renderer object.
 	 *
-	 * @var array
+	 * @var Renderer
 	 */
-	private static $default_story_args;
+	public $renderer;
 
 	/**
-	 * Default query arguments.
+	 * Class constructor
 	 *
-	 * @var array
+	 * @param array $story_attributes          {
+	 *                                         An array of story attributes.
+	 *
+	 *     @type string $view_type                 Stories View type. Default circles.
+	 *     @type int    $number_of_columns         Number of columns to show in grid view. Default 2.
+	 *     @type bool   $show_title                Whether to show story title or not. Default false.
+	 *     @type bool   $show_author               Whether to show story author or not. Default false.
+	 *     @type bool   $show_date                 Whether to show story date or not. Default false.
+	 *     @type bool   $show_story_poster         Whether to show story story poster or show story player. Default true.
+	 *     @type bool   $show_stories_archive_link Whether to show view all link or not. Default false.
+	 *     @type string $stories_archive_label     The label for view all link. Default 'View all stories'.
+	 *     @type string $list_view_image_alignment The list mode image alignment. Default 'left'.
+	 *     @type string $class                     Additional CSS classes for the container. Default empty string.
+	 * }
+	 * @param array $query_arguments           An array of query arguments for story. @see WP_Query::parse_query() for
+	 *                                         all available arguments.
 	 */
-	private static $default_query_args;
+	public function __construct( array $story_attributes = [], array $query_arguments = [] ) {
+
+		$this->story_attributes = $story_attributes;
+		$this->query_arguments  = $query_arguments;
+	}
 
 	/**
-	 * Runs once before any test in the class run.
+	 * Retrieves an array of the latest stories, or Stories matching the given criteria.
 	 *
-	 * @param \WP_UnitTest_Factory $factory Factory class object.
+	 * @return array An array of Story posts.
 	 */
-	public static function wpSetUpBeforeClass( $factory ) {
+	public function get_stories() {
 
-		self::$testee = new Testee();
+		$query_args    = $this->get_query_args();
+		$stories_query = new WP_Query( $query_args );
+		$posts         = ( ! empty( $stories_query->posts ) && is_array( $stories_query->posts ) ) ? $stories_query->posts : [];
 
-		self::$story_id = $factory->post->create(
-			[
-				'post_type'    => Story_CPT::POST_TYPE_SLUG,
-				'post_title'   => 'Example title',
-				'post_status'  => 'publish',
-				'post_content' => 'Example content',
-			]
-		);
+		return $posts;
+	}
 
-		self::$default_story_args = [
+	/**
+	 * Instantiates the renderer classes based on the view type.
+	 *
+	 * @return Renderer Renderer Instance.
+	 */
+	public function get_renderer() {
+
+		$story_attributes = $this->get_story_attributes();
+		$view_type        = ( ! empty( $story_attributes['view_type'] ) ) ? $story_attributes['view_type'] : '';
+
+		switch ( $view_type ) {
+			case 'carousel':
+				$renderer = new Carousel_Renderer( $this );
+				break;
+
+			case 'circles':
+			case 'list':
+			case 'grid':
+			default:
+				$renderer = new Generic_Renderer( $this );
+		}
+
+		$renderer->init();
+
+		return $renderer;
+	}
+
+	/**
+	 * Renders the stories output.
+	 *
+	 * @return string
+	 */
+	public function render() {
+
+		$this->renderer = $this->get_renderer();
+
+		return $this->renderer->render();
+	}
+
+	/**
+	 * Gets an array of story attributes.
+	 *
+	 * @return array An array of story attributes.
+	 */
+	public function get_story_attributes() {
+
+		$default_attributes = [
 			'view_type'                 => 'circles',
 			'number_of_columns'         => 2,
 			'show_title'                => false,
@@ -80,64 +151,30 @@ class Story_Query extends \WP_UnitTestCase {
 			'show_date'                 => false,
 			'show_story_poster'         => true,
 			'show_stories_archive_link' => false,
-			'stories_archive_label'     => 'View all stories',
+			'stories_archive_label'     => __( 'View all stories', 'web-stories' ),
 			'list_view_image_alignment' => 'left',
 			'class'                     => '',
 		];
 
-		self::$default_query_args = [
-			'post_type'        => Story_CPT::POST_TYPE_SLUG,
+		return wp_parse_args( $this->story_attributes, $default_attributes );
+	}
+
+	/**
+	 * Returns arguments to be passed to the WP_Query object initialization.
+	 *
+	 * @return array An array of query arguments.
+	 */
+	protected function get_query_args() {
+
+		$default_query_args = [
+			'post_type'        => Story_Post_Type::POST_TYPE_SLUG,
 			'posts_per_page'   => 10,
 			'post_status'      => 'publish',
 			'suppress_filters' => false,
 			'no_found_rows'    => true,
 		];
 
-	}
-
-	/**
-	 * Test that instance of
-	 *
-	 * @covers ::render
-	 */
-	public function test_render() {
-		$output = get_echo( [ self::$testee, 'render' ] );
-
-		$this->assertInstanceOf( Generic_Renderer::class, self::$testee->renderer );
-	}
-
-	/**
-	 * Test that get_stories method returns valid story.
-	 *
-	 * @covers ::get_stories
-	 */
-	public function test_get_stories_returns_valid_story() {
-
-		$story_posts = self::$testee->get_stories();
-		$this->assertSame( self::$story_id, $story_posts[0]->ID );
-	}
-
-	/**
-	 * Test that get_stories method returns valid story.
-	 *
-	 * @covers ::get_stories
-	 */
-	public function test_get_stories_returns_empty_array() {
-
-		$stories_obj = new Testee( [], [ 'post_type' => 'draft' ] );
-		$story_posts = $stories_obj->get_stories();
-		$this->assertEmpty( $story_posts );
-	}
-
-	/**
-	 * Test story arguments are equal.
-	 *
-	 * @covers ::get_story_attributes
-	 */
-	public function test_default_story_args_equality() {
-
-		$story_args = self::$testee->get_story_attributes();
-		$this->assertSame( self::$default_story_args, $story_args );
+		return wp_parse_args( $this->query_arguments, $default_query_args );
 	}
 
 }

--- a/tests/phpunit/tests/Story_Query.php
+++ b/tests/phpunit/tests/Story_Query.php
@@ -83,6 +83,7 @@ class Story_Query extends \WP_UnitTestCase {
 			'stories_archive_label'     => 'View all stories',
 			'list_view_image_alignment' => 'left',
 			'class'                     => '',
+			'circle_size'               => 150,
 		];
 
 		self::$default_query_args = [


### PR DESCRIPTION
## Summary

- Adds a Stories class that can be used by users to list stories in different view formats based on the attributes provided.

## Relevant Technical Choices

- `Stories` class which uses the Renderer classes to display stories based on given attributes.
- `GenericRenderer` class which handles the circles, grid, list, and carousel story view types.
- `CarouselRenderer` class to render stories in carousel view.

## Testing Instructions

Displaying stories with default arguments.
```php
$stories = new Stories();
echo $stories->render();
```

Displaying Stories with user-provided arguments.
```php
$story_attributes = [
	'view_type'         => 'carousel',
	'show_story_poster' => false,
	'show_title'        => true,
];

$query_arguments = [
	'posts_per_page' => 10,
	'order'          => 'ASC',
	'orderby'        => 'title',
];
$stories = new Story_Query( $story_attributes, $query_arguments );
echo $stories->render( [ 'height' => 485, 'width' => 320 ] );
```
