### PR TITLE
Shortcode API

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -41,6 +41,7 @@ use Google\Web_Stories\Block\Embed_Block;
 use Google\Web_Stories\REST_API\Stories_Settings_Controller;
 use Google\Web_Stories\REST_API\Stories_Users_Controller;
 use Google\Web_Stories\Shortcode\Embed_Shortcode;
+use Google\Web_Stories\Shortcode\Stories_Shortcode;
 
 /**
  * Plugin class.
@@ -217,6 +218,9 @@ class Plugin {
 		// Embed shortcode.
 		$this->embed_shortcode = new Embed_Shortcode();
 		add_action( 'init', [ $this->embed_shortcode, 'init' ] );
+
+		$story_shortcode = new Stories_Shortcode();
+		add_action( 'init', [ $story_shortcode, 'init' ] );
 
 		// Frontend.
 		$this->discovery = new Discovery();

--- a/includes/Shortcode/Stories_Shortcode.php
+++ b/includes/Shortcode/Stories_Shortcode.php
@@ -72,7 +72,7 @@ class Stories_Shortcode {
 		$this->attributes = shortcode_atts(
 			[
 				'view'                      => 'circles',
-				'columns'                   => 2,
+				'columns'                   => 1,
 				'title'                     => 'false',
 				'author'                    => 'false',
 				'date'                      => 'false',

--- a/includes/Shortcode/Stories_Shortcode.php
+++ b/includes/Shortcode/Stories_Shortcode.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Class Stories_Shortcode.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Shortcode;
+
+use Google\Web_Stories\Story_Query as Stories;
+
+/**
+ * Class Stories_Shortcode
+ *
+ * @package Google\Web_Stories\Shortcode
+ */
+class Stories_Shortcode {
+
+	/**
+	 * Shortcode attributes.
+	 *
+	 * @var array
+	 */
+	private $attributes;
+
+	/**
+	 * Shortcode name.
+	 *
+	 * @var string
+	 */
+	const SHORTCODE_NAME = 'stories';
+
+	/**
+	 * Initializes the Stories shortcode.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_shortcode( self::SHORTCODE_NAME, [ $this, 'render_stories' ] );
+	}
+
+	/**
+	 * Callback for the shortcode.
+	 *
+	 * This will render the stories according to given
+	 * shortcode attributes.
+	 *
+	 * @param array $attributes Shortcode attributes.
+	 *
+	 * @return string Story markup.
+	 */
+	public function render_stories( array $attributes ) {
+		$this->attributes = shortcode_atts(
+			[
+				'view'                      => 'circles',
+				'columns'                   => 2,
+				'title'                     => 'false',
+				'author'                    => 'false',
+				'date'                      => 'false',
+				'story_poster'              => 'true',
+				'archive_link'              => 'false',
+				'archive_label'             => __( 'View all stories', 'web-stories' ),
+				'list_view_image_alignment' => 'left',
+				'class'                     => '',
+				'number'                    => 10,
+				'order'                     => 'DESC',
+			],
+			$attributes
+		);
+
+		$stories = new Stories( $this->prepare_story_attrs(), $this->prepare_story_args() );
+
+		return $stories->render();
+	}
+
+	/**
+	 * Prepare story attributes.
+	 *
+	 * @return array Attributes to pass to Story_Query class.
+	 */
+	private function prepare_story_attrs() {
+		$attrs = [];
+
+		$attrs['view_type']                 = (string) $this->attributes['view'];
+		$attrs['number_of_columns']         = (int) $this->attributes['columns'];
+		$attrs['show_title']                = (bool) 'true' === $this->attributes['title'];
+		$attrs['show_author']               = (bool) 'true' === $this->attributes['author'];
+		$attrs['show_date']                 = (bool) 'true' === $this->attributes['date'];
+		$attrs['show_story_poster']         = (bool) 'true' === $this->attributes['story_poster'];
+		$attrs['show_story_archive_link']   = (bool) 'true' === $this->attributes['archive_link'];
+		$attrs['show_story_archive_label']  = (bool) 'true' === $this->attributes['archive_label'];
+		$attrs['list_view_image_alignment'] = (string) $this->attributes['list_view_image_alignment'];
+		$attrs['class']                     = (string) $this->attributes['class'];
+
+		return $attrs;
+	}
+
+	/**
+	 * Prepare story arguments.
+	 *
+	 * @return array Array of story arguments to pass to Story_Query.
+	 */
+	private function prepare_story_args() {
+		$args = [];
+
+		// Show 100 stories at most to avoid 500 errors.
+		$args['posts_per_page'] = min( (int) $this->attributes['number'], 100 );
+		$args['order']          = 'ASC' === $this->attributes['order'] ? 'ASC' : 'DESC';
+
+		return $args;
+	}
+}

--- a/includes/Shortcode/Stories_Shortcode.php
+++ b/includes/Shortcode/Stories_Shortcode.php
@@ -36,13 +36,6 @@ use Google\Web_Stories\Story_Query as Stories;
 class Stories_Shortcode {
 
 	/**
-	 * Shortcode attributes.
-	 *
-	 * @var array
-	 */
-	private $attributes;
-
-	/**
 	 * Shortcode name.
 	 *
 	 * @var string
@@ -64,12 +57,12 @@ class Stories_Shortcode {
 	 * This will render the stories according to given
 	 * shortcode attributes.
 	 *
-	 * @param array $attributes Shortcode attributes.
+	 * @param array $attrs Shortcode attributes.
 	 *
 	 * @return string Story markup.
 	 */
-	public function render_stories( array $attributes ) {
-		$this->attributes = shortcode_atts(
+	public function render_stories( array $attrs ) {
+		$attributes = shortcode_atts(
 			[
 				'view'                      => 'circles',
 				'columns'                   => 1,
@@ -81,13 +74,15 @@ class Stories_Shortcode {
 				'archive_label'             => __( 'View all stories', 'web-stories' ),
 				'list_view_image_alignment' => 'left',
 				'class'                     => '',
+				'circle_size'               => 150,
 				'number'                    => 10,
 				'order'                     => 'DESC',
 			],
-			$attributes
+			$attrs,
+			self::SHORTCODE_NAME
 		);
 
-		$stories = new Stories( $this->prepare_story_attrs(), $this->prepare_story_args() );
+		$stories = new Stories( $this->prepare_story_attrs( $attributes ), $this->prepare_story_args( $attributes ) );
 
 		return $stories->render();
 	}
@@ -95,37 +90,40 @@ class Stories_Shortcode {
 	/**
 	 * Prepare story attributes.
 	 *
+	 * @param array $attributes Shortcode attributes.
+	 *
 	 * @return array Attributes to pass to Story_Query class.
 	 */
-	private function prepare_story_attrs() {
-		$attrs = [];
+	private function prepare_story_attrs( array $attributes ) {
 
-		$attrs['view_type']                 = (string) $this->attributes['view'];
-		$attrs['number_of_columns']         = (int) $this->attributes['columns'];
-		$attrs['show_title']                = (bool) 'true' === $this->attributes['title'];
-		$attrs['show_author']               = (bool) 'true' === $this->attributes['author'];
-		$attrs['show_date']                 = (bool) 'true' === $this->attributes['date'];
-		$attrs['show_story_poster']         = (bool) 'true' === $this->attributes['story_poster'];
-		$attrs['show_story_archive_link']   = (bool) 'true' === $this->attributes['archive_link'];
-		$attrs['show_story_archive_label']  = (bool) 'true' === $this->attributes['archive_label'];
-		$attrs['list_view_image_alignment'] = (string) $this->attributes['list_view_image_alignment'];
-		$attrs['class']                     = (string) $this->attributes['class'];
-
-		return $attrs;
+		return [
+			'view_type'                 => (string) $attributes['view'],
+			'number_of_columns'         => (int) $attributes['columns'],
+			'show_title'                => ( 'true' === $attributes['title'] ),
+			'show_author'               => ( 'true' === $attributes['author'] ),
+			'show_date'                 => ( 'true' === $attributes['date'] ),
+			'show_story_poster'         => ( 'true' === $attributes['story_poster'] ),
+			'show_story_archive_link'   => ( 'true' === $attributes['archive_link'] ),
+			'show_story_archive_label'  => ( 'true' === $attributes['archive_label'] ),
+			'list_view_image_alignment' => (string) $attributes['list_view_image_alignment'],
+			'class'                     => (string) $attributes['class'],
+			'circle_size'               => (int) $attributes['circle_size'],
+		];
 	}
 
 	/**
 	 * Prepare story arguments.
 	 *
+	 * @param array $attributes Array of arguments for Story Query.
+	 *
 	 * @return array Array of story arguments to pass to Story_Query.
 	 */
-	private function prepare_story_args() {
-		$args = [];
+	private function prepare_story_args( array $attributes ) {
 
-		// Show 100 stories at most to avoid 500 errors.
-		$args['posts_per_page'] = min( (int) $this->attributes['number'], 100 );
-		$args['order']          = 'ASC' === $this->attributes['order'] ? 'ASC' : 'DESC';
-
-		return $args;
+		return [
+			// Show 100 stories at most to avoid 500 errors.
+			'posts_per_page' => min( (int) $attributes['number'], 100 ),
+			'order'          => 'ASC' === $attributes['order'] ? 'ASC' : 'DESC',
+		];
 	}
 }

--- a/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
+++ b/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
@@ -136,4 +136,31 @@ class Stories_Shortcode extends \WP_UnitTestCase {
 		$args = $this->call_private_method( $stories_shortcode, 'prepare_story_args' );
 		$this->assertSame( 100, $args['posts_per_page'] );
 	}
+
+	/**
+	 * @covers ::render_stories
+	 */
+	public function test_shortcode_default_attrs() {
+		$shortcode_obj = new Testee();
+
+		$default = [
+			'view'                      => 'circles',
+			'columns'                   => 1,
+			'title'                     => 'false',
+			'author'                    => 'false',
+			'date'                      => 'false',
+			'story_poster'              => 'true',
+			'archive_link'              => 'false',
+			'archive_label'             => __( 'View all stories', 'web-stories' ),
+			'list_view_image_alignment' => 'left',
+			'class'                     => '',
+			'number'                    => 10,
+			'order'                     => 'DESC',
+		];
+
+		$this->call_private_method( $shortcode_obj, 'render_stories', [ [] ] );
+		$attrs = $this->get_private_property( $shortcode_obj, 'attributes' );
+
+		$this->assertSameSets( $default, $attrs );
+	}
 }

--- a/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
+++ b/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
@@ -130,6 +130,7 @@ class Stories_Shortcode extends \WP_UnitTestCase {
 		];
 
 		$args = $this->call_private_method( $stories_shortcode, 'prepare_story_args', [ $attributes ] );
+		$this->assertArrayHasKey( 'posts_per_page', $args );
 		$this->assertSame( 100, $args['posts_per_page'] );
 	}
 
@@ -169,6 +170,6 @@ class Stories_Shortcode extends \WP_UnitTestCase {
 
 		$actual = $this->call_private_method( $shortcode, 'prepare_story_attrs', [ $attributes ] );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEqualSets( $expected, $actual );
 	}
 }

--- a/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
+++ b/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Stories_Shortcode Unit Test class.
+ *
+ * @package   Google\Web_Stories\Tests
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests\Shortcode;
+
+use Google\Web_Stories\Shortcode\Stories_Shortcode as Testee;
+use Google\Web_Stories\Story_Post_Type;
+use Google\Web_Stories\Tests\Private_Access;
+
+/**
+ * @coversDefaultClass \Google\Web_Stories\Shortcode\Stories_Shortcode
+ */
+class Stories_Shortcode extends \WP_UnitTestCase {
+
+	use Private_Access;
+
+	/**
+	 * Story ID.
+	 *
+	 * @var int
+	 */
+	private static $story_id;
+
+	/**
+	 * Run before any test is run and class is being setup.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		require dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/includes/compat/amp.php';
+
+		self::$story_id = $factory->post->create(
+			[
+				'post_type'   => Story_Post_Type::POST_TYPE_SLUG,
+				'post_status' => 'publish',
+				'post_title'  => 'Test Story',
+			]
+		);
+	}
+
+	/**
+	 * Runs after all tests are run.
+	 */
+	public function tearDown() {
+		remove_shortcode( Testee::SHORTCODE_NAME );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers ::render_stories
+	 * @covers ::prepare_story_args
+	 * @covers ::prepare_story_attrs
+	 */
+	public function test_render_carousel_view_in_shortcode() {
+		$stories_shortcode = new Testee();
+		$actual            = $stories_shortcode->render_stories(
+			[
+				'view' => 'carousel',
+			]
+		);
+
+		$this->assertTrue( false !== strpos( $actual, '<amp-carousel' ) );
+	}
+
+	/**
+	 * @covers ::render_stories
+	 * @covers ::prepare_story_attrs
+	 * @covers ::prepare_story_args
+	 */
+	public function test_render_circles_view_in_shortcode() {
+		$stories_shortcode = new Testee();
+		$actual            = $stories_shortcode->render_stories(
+			[
+				'view' => 'circles',
+			]
+		);
+
+		$this->assertTrue( false !== strpos( $actual, '<div class="web-stories-list__story-wrapper has-poster">' ) );
+	}
+
+	/**
+	 * Test story player while using shortcode.
+	 *
+	 * @covers ::render_stories
+	 */
+	public function test_render_story_player_in_shortcode() {
+		$stories_shortcode = new Testee();
+		$actual            = $stories_shortcode->render_stories(
+			[
+				'story_poster' => 'false',
+				'view'         => 'grid',
+			]
+		);
+
+		$this->assertTrue( false !== strpos( $actual, '<amp-story-player' ) );
+	}
+
+	/**
+	 * Stories should not be greater than 100.
+	 *
+	 * @covers ::prepare_story_args
+	 */
+	public function test_max_number_for_stories() {
+		$stories_shortcode = new Testee();
+		$this->set_private_property(
+			$stories_shortcode,
+			'attributes',
+			[
+				'number' => 1000000,
+				'order'  => 'DESC',
+			]
+		);
+
+		$args = $this->call_private_method( $stories_shortcode, 'prepare_story_args' );
+		$this->assertSame( 100, $args['posts_per_page'] );
+	}
+}

--- a/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
+++ b/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
@@ -161,6 +161,6 @@ class Stories_Shortcode extends \WP_UnitTestCase {
 		$this->call_private_method( $shortcode_obj, 'render_stories', [ [] ] );
 		$attrs = $this->get_private_property( $shortcode_obj, 'attributes' );
 
-		$this->assertSameSets( $default, $attrs );
+		$this->assertSame( $default, $attrs );
 	}
 }

--- a/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
+++ b/tests/phpunit/tests/Shortcode/Stories_Shortcode.php
@@ -124,43 +124,51 @@ class Stories_Shortcode extends \WP_UnitTestCase {
 	 */
 	public function test_max_number_for_stories() {
 		$stories_shortcode = new Testee();
-		$this->set_private_property(
-			$stories_shortcode,
-			'attributes',
-			[
-				'number' => 1000000,
-				'order'  => 'DESC',
-			]
-		);
+		$attributes        = [
+			'number' => 1000000,
+			'order'  => 'DESC',
+		];
 
-		$args = $this->call_private_method( $stories_shortcode, 'prepare_story_args' );
+		$args = $this->call_private_method( $stories_shortcode, 'prepare_story_args', [ $attributes ] );
 		$this->assertSame( 100, $args['posts_per_page'] );
 	}
 
 	/**
-	 * @covers ::render_stories
+	 * @covers ::prepare_story_attrs
 	 */
-	public function test_shortcode_default_attrs() {
-		$shortcode_obj = new Testee();
+	public function test_prepare_story_attrs() {
+		$shortcode = new Testee();
 
-		$default = [
-			'view'                      => 'circles',
-			'columns'                   => 1,
-			'title'                     => 'false',
-			'author'                    => 'false',
-			'date'                      => 'false',
-			'story_poster'              => 'true',
-			'archive_link'              => 'false',
-			'archive_label'             => __( 'View all stories', 'web-stories' ),
+		$expected = [
+			'view_type'                 => 'grid',
+			'number_of_columns'         => 2,
+			'show_title'                => true,
+			'show_author'               => true,
+			'show_date'                 => true,
+			'show_story_poster'         => true,
+			'show_story_archive_link'   => false,
+			'show_story_archive_label'  => true,
 			'list_view_image_alignment' => 'left',
-			'class'                     => '',
-			'number'                    => 10,
-			'order'                     => 'DESC',
+			'class'                     => 'dummy',
+			'circle_size'               => 200,
 		];
 
-		$this->call_private_method( $shortcode_obj, 'render_stories', [ [] ] );
-		$attrs = $this->get_private_property( $shortcode_obj, 'attributes' );
+		$attributes = [
+			'view'                      => 'grid',
+			'columns'                   => 2,
+			'title'                     => 'true',
+			'author'                    => 'true',
+			'date'                      => 'true',
+			'story_poster'              => 'true',
+			'archive_link'              => 'randomtext',
+			'archive_label'             => 'true',
+			'list_view_image_alignment' => 'left',
+			'class'                     => 'dummy',
+			'circle_size'               => '200',
+		];
 
-		$this->assertSame( $default, $attrs );
+		$actual = $this->call_private_method( $shortcode, 'prepare_story_attrs', [ $attributes ] );
+
+		$this->assertEquals( $expected, $actual );
 	}
 }


### PR DESCRIPTION
### Create a stories shortcode API in order to embed stories within shortcode blocks and classic editor.

#### Usage

1. Insert this shortcode in either Shortcode Block or Classic Editor.
2. Save the Post and Visit it on Frontend.

```php
[stories view="circles" number="2" class="my-stories-wrapper" /]
```

#### Result

![screenshot-content local-2020 11 27-13_52_30](https://user-images.githubusercontent.com/1442637/100427103-f2778680-30b7-11eb-8853-d9a7619b0f7c.png)

#### Shortcode Attributes.

1.  `view`: View type for the stories. Example: circles, grid, list etc.
2.  `columns`: Number of columns for the stories.
3.  `title`: Whether to show title in the stories.
4.  `author`: Whether to show author name in the stories.
5.  `date`: Whether to display date in the stories.
6.  `story_poster`: Whether to show story poster.
7.  `archive_link`: Whether to display stories archive link.
8.  `archive_label`: Label for archive label.
9.  `list_view_image_alignment`: Useful in List mode. Alignment for image in list mode.
10. `class`: Classes for the stories wrapper.
11. `number`: How many number of stories to display. Max: 100
12. `order`: Order for rendering stories. Stories are rendered based on their publish timing. Possible options are `latest`/`oldest`/`alphabetical`/`reverse-alphabetical`