### PR TITLE
#4 Lightbox: Add 'lightbox' support for the web stories block

### DIFF
--- a/assets/src/lightbox/index.js
+++ b/assets/src/lightbox/index.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import initializeWebStoryLightbox from './web-stories-lightbox';
+
+window.addEventListener('load', () => {
+  initializeWebStoryLightbox();
+});

--- a/assets/src/lightbox/index.js
+++ b/assets/src/lightbox/index.js
@@ -15,10 +15,15 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
  * Internal dependencies
  */
 import initializeWebStoryLightbox from './web-stories-lightbox';
 
-window.addEventListener('load', () => {
+domReady(() => {
   initializeWebStoryLightbox();
 });

--- a/assets/src/lightbox/web-stories-lightbox.js
+++ b/assets/src/lightbox/web-stories-lightbox.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Handles the 'amp-story-player' lightbox.
+ *
+ * Displays the story that user interacted with in a lightbox.
+ */
+class Lightbox {
+  constructor(wrapperDiv) {
+    if ('undefined' === typeof wrapperDiv) {
+      return;
+    }
+
+    this.lightboxInitialized = false;
+    this.wrapperDiv = wrapperDiv;
+    this.lightboxElement = this.wrapperDiv.querySelector(
+      '.web-stories-list__lightbox'
+    );
+    this.player = this.lightboxElement.querySelector('amp-story-player');
+
+    if (
+      'undefined' === typeof this.player ||
+      'undefined' === typeof this.lightboxElement
+    ) {
+      return;
+    }
+
+    if (this.player.isReady && !this.lightboxInitialized) {
+      this.initializeLightbox();
+    }
+
+    this.player.addEventListener('ready', () => {
+      if (!this.lightboxInitialized) {
+        this.initializeLightbox();
+      }
+    });
+
+    // Event triggered when user clicks on close (X) button.
+    this.player.addEventListener('amp-story-player-close', () => {
+      this.player.pause();
+      this.lightboxElement.classList.toggle('show');
+    });
+  }
+
+  initializeLightbox() {
+    /**
+     * Stop stories from auto-play.
+     *
+     * https://github.com/ampproject/amphtml/issues/31334#issuecomment-733998656
+     */
+    this.player.pause();
+
+    this.stories = this.player.getStories();
+    this.bindStoryClickListeners();
+    this.lightboxInitialized = true;
+  }
+
+  bindStoryClickListeners() {
+    const cards = this.wrapperDiv.querySelectorAll(
+      '.web-stories-list__story-wrapper:not(.archive-link-card)'
+    );
+
+    cards.forEach((card, index) => {
+      card.addEventListener('click', (event) => {
+        event.preventDefault();
+        this.player.show(this.stories[index].href);
+        this.lightboxElement.classList.toggle('show');
+      });
+    });
+  }
+}
+
+export default function initializeWebStoryLightbox() {
+  const webStoryBlocks = document.getElementsByClassName('web-stories-list');
+  if ('undefined' !== typeof webStoryBlocks) {
+    Array.from(webStoryBlocks).forEach((webStoryBlock) => {
+      /* eslint-disable-next-line no-new -- we do not store the object as no further computation required. */
+      new Lightbox(webStoryBlock);
+    });
+  }
+}

--- a/includes/Stories_Renderer/Carousel_Renderer.php
+++ b/includes/Stories_Renderer/Carousel_Renderer.php
@@ -101,6 +101,13 @@ class Carousel_Renderer extends Renderer {
 				?>
 			</amp-carousel>
 			<?php $this->maybe_render_archive_link(); ?>
+			<?php
+			if ( ! $this->is_amp_request() ) {
+				$this->render_stories_with_lightbox_noamp();
+			} else {
+				$this->render_stories_with_lightbox_amp();
+			}
+			?>
 		</div>
 		<?php
 		$content = (string) ob_get_clean();

--- a/includes/Stories_Renderer/Generic_Renderer.php
+++ b/includes/Stories_Renderer/Generic_Renderer.php
@@ -26,8 +26,6 @@
 
 namespace Google\Web_Stories\Stories_Renderer;
 
-use Google\Web_Stories\Embed_Base;
-
 /**
  * Generic_Renderer class.
  *
@@ -56,21 +54,6 @@ class Generic_Renderer extends Renderer {
 	}
 
 	/**
-	 * Enqueue assets.
-	 *
-	 * @return void
-	 */
-	public function assets() {
-
-		parent::assets();
-
-		if ( $this->is_view_type( 'grid' ) && ! $this->is_amp_request() ) {
-			$this->enqueue_style( Embed_Base::STORY_PLAYER_HANDLE );
-			$this->enqueue_script( Embed_Base::STORY_PLAYER_HANDLE );
-		}
-	}
-
-	/**
 	 * Renders the stories output for given attributes.
 	 *
 	 * @SuppressWarnings(PHPMD.UnusedLocalVariable)
@@ -96,6 +79,13 @@ class Generic_Renderer extends Renderer {
 				$this->render_single_story_content();
 				$this->next();
 			}
+
+			if ( ! $this->is_amp_request() ) {
+				$this->render_stories_with_lightbox_noamp();
+			} else {
+				$this->render_stories_with_lightbox_amp();
+			}
+
 			$this->maybe_render_archive_link();
 			?>
 		</div>

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -58,6 +58,13 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	const STYLE_HANDLE = 'web-stories-list-styles';
 
 	/**
+	 * Web Stories stylesheet handle.
+	 *
+	 * @var string
+	 */
+	const LIGHTBOX_SCRIPT_HANDLE = 'lightbox';
+
+	/**
 	 * Stories object
 	 *
 	 * @var Stories Stories object
@@ -254,7 +261,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 			$this->enqueue_script( Embed_Base::STORY_PLAYER_HANDLE );
 
 			// Web Stories Lightbox script.
-			$this->enqueue_script( 'lightbox', [ Embed_Base::STORY_PLAYER_HANDLE ] );
+			$this->enqueue_script( self::LIGHTBOX_SCRIPT_HANDLE, [ Embed_Base::STORY_PLAYER_HANDLE ] );
 
 		}
 	}
@@ -432,24 +439,32 @@ abstract class Renderer implements RenderingInterface, Iterator {
 		$single_story_classes = $this->get_single_story_classes();
 		$story_styles         = $this->is_view_type( 'circles' ) ? sprintf( '--size:%1$spx', $this->attributes['circle_size'] ) : '';
 		$story_styles        .= $this->is_view_type( 'carousel' ) ? sprintf( '--width:%1$spx', $this->width ) : '';
+		$lightbox_state       = 'lightbox' . $this->current()->get_id();
 
-		$lightbox_state          = "lightbox{$this->current()->get_id()}";
-		$lightbox_set_state_attr = ( $this->is_amp_request() ) ? sprintf(
-			'on="tap:AMP.setState({%1$s: ! %1$s})"',
-			$lightbox_state
-		) : '';
-
-		?>
-
-		<div
-			class="<?php echo esc_attr( $single_story_classes ); ?>"
-			<?php echo wp_kses( $lightbox_set_state_attr, 'on' ); ?>
-			style="<?php echo esc_attr( $story_styles ); ?>"
-		>
-			<?php $this->render_story_with_poster(); ?>
-		</div>
-		<?php
-
+		if ( $this->is_amp_request() ) {
+			?>
+			<div
+				class="<?php echo esc_attr( $single_story_classes ); ?>"
+				on="<?php echo esc_attr( sprintf( 'tap:AMP.setState({%1$s: ! %1$s})', $lightbox_state ) ); ?>"
+				style="<?php echo esc_attr( $story_styles ); ?>"
+			>
+				<?php
+				$this->render_story_with_poster();
+				?>
+			</div>
+			<?php
+		} else {
+			?>
+			<div
+				class="<?php echo esc_attr( $single_story_classes ); ?>"
+				style="<?php echo esc_attr( $story_styles ); ?>"
+			>
+				<?php
+					$this->render_story_with_poster();
+				?>
+			</div>
+			<?php
+		}
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10693,11 +10693,11 @@
       }
     },
     "@wordpress/dom-ready": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.11.0.tgz",
-      "integrity": "sha512-q9MZqYPHUtioT/2tgzyAtnEFXRgUJ6eMxLDQaOprBQkGoD2Ue/V+wEX6cJGy+x8AafFataPC2i2jPsnYqE9+zQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.12.0.tgz",
+      "integrity": "sha512-FLmXpCZimNc0FUpLP9+eo/AFQs1tXlfDQ0GUqX/i4oZXpP4qSoZ18MNPdRYmDEYlfzWGHSfbSJQcD8PnlYr4Ew==",
       "requires": {
-        "@babel/runtime": "^7.11.2"
+        "@babel/runtime": "^7.12.5"
       },
       "dependencies": {
         "@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@wordpress/components": "^11.1.1",
     "@wordpress/compose": "^3.22.0",
     "@wordpress/data": "^4.25.0",
+    "@wordpress/dom-ready": "^2.12.0",
     "@wordpress/element": "^2.18.0",
     "@wordpress/i18n": "^3.16.0",
     "@wordpress/viewport": "^2.24.0",

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -197,6 +197,26 @@ const dashboard = {
   },
 };
 
+const webStoriesScripts = {
+  ...sharedConfig,
+  entry: {
+    lightbox: './assets/src/lightbox/index.js',
+  },
+  plugins: [
+    process.env.BUNDLE_ANALZYER && new BundleAnalyzerPlugin(),
+    new DependencyExtractionWebpackPlugin({
+      injectPolyfill: true,
+    }),
+    new MiniCssExtractPlugin({
+      filename: '../css/[name].css',
+    }),
+    new WebpackBar({
+      name: 'Web Stories Scripts',
+      color: '#357BB5',
+    }),
+  ].filter(Boolean),
+};
+
 const storyEmbedBlock = {
   ...sharedConfig,
   entry: {
@@ -257,4 +277,10 @@ const activationNotice = {
   },
 };
 
-module.exports = [storiesEditor, dashboard, storyEmbedBlock, activationNotice];
+module.exports = [
+  storiesEditor,
+  dashboard,
+  webStoriesScripts,
+  storyEmbedBlock,
+  activationNotice,
+];


### PR DESCRIPTION
## Summary

- Block stories will open on the same page in a lightbox.

## Relevant Technical Choices

- Uses 'amp-lightbox' for the AMP pages.
- Uses custom lightbox for non-AMP pages.

## User-facing changes

- Story cards will display the story in the lightbox on click.

---
