### PR TITLE
- Updates blockType and viewType icons for the 'Web Stories List' block.

### DIFF
--- a/assets/src/web-stories-block/block/components/storiesBlockConfigurationPanel.js
+++ b/assets/src/web-stories-block/block/components/storiesBlockConfigurationPanel.js
@@ -91,7 +91,8 @@ function BlockConfigurationPanel({
             }}
           >
             <TypeMedia>
-              <Icon icon={option.icon} />
+              {'viewType' === selectionType && <Icon icon={option.panelIcon} />}
+              {'blockType' === selectionType && <Icon icon={option.icon} />}
             </TypeMedia>
             <TypeCardBody>{option.label}</TypeCardBody>
           </TypeCard>

--- a/assets/src/web-stories-block/block/components/storiesInspectorControls.js
+++ b/assets/src/web-stories-block/block/components/storiesInspectorControls.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 /**
  * WordPress dependencies
@@ -47,6 +48,22 @@ import {
 } from '../constants';
 import { isShowing } from '../util';
 import AuthorSelection from './authorSelection';
+
+const StyledTextArea = styled(TextControl)`
+  width: 80%;
+  margin-left: auto;
+`;
+
+const StyledNotice = styled(Notice)`
+  margin: 0 0 20px 0;
+`;
+
+const StyledToggle = styled(ToggleControl)`
+  .components-base-control__help {
+    width: 80%;
+    margin-left: auto;
+  }
+`;
 
 /**
  * StoriesInspectorControls props.
@@ -90,7 +107,7 @@ const StoriesInspectorControls = (props) => {
     showFilters = true,
   } = props;
 
-  const { fieldStates } = useConfig();
+  const { fieldStates, archiveURL } = useConfig();
 
   useEffect(() => {
     // Set default field state on load.
@@ -111,6 +128,11 @@ const StoriesInspectorControls = (props) => {
     }
   );
 
+  const archiveLink = `<a target="__blank" href="${archiveURL}">${__(
+    'View archive page',
+    'web-stories'
+  )}</a>`;
+
   const previewLink = select('core/editor').getEditedPostPreviewLink();
   const carouselMessage = sprintf(
     /* Translators: Carousel informational message. 1: Preview link. */
@@ -128,13 +150,13 @@ const StoriesInspectorControls = (props) => {
         title={__('Story settings', 'web-stories')}
       >
         {CAROUSEL_VIEW_TYPE === viewType && (
-          <Notice
+          <StyledNotice
             className="web-stories-carousel-message"
             isDismissible={false}
             status="warning"
           >
             <RawHTML>{carouselMessage}</RawHTML>
-          </Notice>
+          </StyledNotice>
         )}
 
         {fieldState[viewType] &&
@@ -143,7 +165,7 @@ const StoriesInspectorControls = (props) => {
 
             if (!readonly) {
               return (
-                <ToggleControl
+                <StyledToggle
                   key={`${field}__control`}
                   label={label}
                   checked={show}
@@ -162,6 +184,10 @@ const StoriesInspectorControls = (props) => {
                       });
                     }
                   }}
+                  help={
+                    'archive_link' === field &&
+                    show && <RawHTML>{archiveLink}</RawHTML>
+                  }
                 />
               );
             }
@@ -170,7 +196,7 @@ const StoriesInspectorControls = (props) => {
           })}
         {fieldState[viewType] &&
           isShowing('archive_link', fieldState[viewType]) && (
-            <TextControl
+            <StyledTextArea
               label={__("'View All Stories' Link label", 'web-stories')}
               value={viewAllLinkLabel}
               placeholder={__('View All Stories', 'web-stories')}

--- a/assets/src/web-stories-block/block/constants.js
+++ b/assets/src/web-stories-block/block/constants.js
@@ -27,6 +27,13 @@ import {
   LATESTS_STORIES_BLOCK_ICON,
   CAROUSEL_VIEW_TYPE_ICON,
   SELECTED_STORIES_BLOCK_ICON,
+  CIRCLES_VIEW_TYPE_ICON,
+  LIST_VIEW_TYPE_ICON,
+  GRID_VIEW_TYPE_ICON,
+  BOX_CAROUSEL_CONFIG_ICON,
+  LIST_VIEW_CONFIG_ICON,
+  CIRCLE_CAROUSEL_CONFIG_ICON,
+  GRID_VIEW_CONFIG_ICON,
 } from './icons';
 
 /**
@@ -60,33 +67,34 @@ export const BLOCK_TYPES = [
  * Block controls icons.
  */
 export const GRID_VIEW_TYPE = 'grid';
-export const GRID_VIEW_TYPE_ICON = 'screenoptions';
 export const LIST_VIEW_TYPE = 'list';
-export const LIST_VIEW_TYPE_ICON = 'editor-justify';
 export const CIRCLES_VIEW_TYPE = 'circles';
-export const CIRCLES_VIEW_TYPE_ICON = 'marker';
 export const CAROUSEL_VIEW_TYPE = 'carousel';
 
 export const VIEW_TYPES = [
   {
     id: CAROUSEL_VIEW_TYPE,
-    label: __('Carousel View', 'web-stories'),
+    label: __('Box Carousel', 'web-stories'),
     icon: CAROUSEL_VIEW_TYPE_ICON,
+    panelIcon: BOX_CAROUSEL_CONFIG_ICON,
   },
   {
     id: CIRCLES_VIEW_TYPE,
-    label: __('Circle View', 'web-stories'),
+    label: __('Circle Carousel', 'web-stories'),
     icon: CIRCLES_VIEW_TYPE_ICON,
+    panelIcon: CIRCLE_CAROUSEL_CONFIG_ICON,
   },
   {
     id: GRID_VIEW_TYPE,
-    label: __('Grid View', 'web-stories'),
+    label: __('Grid', 'web-stories'),
     icon: GRID_VIEW_TYPE_ICON,
+    panelIcon: GRID_VIEW_CONFIG_ICON,
   },
   {
     id: LIST_VIEW_TYPE,
-    label: __('List View', 'web-stories'),
+    label: __('List', 'web-stories'),
     icon: LIST_VIEW_TYPE_ICON,
+    panelIcon: LIST_VIEW_CONFIG_ICON,
   },
 ];
 

--- a/assets/src/web-stories-block/block/edit.js
+++ b/assets/src/web-stories-block/block/edit.js
@@ -52,7 +52,10 @@ function WebStoriesEdit({ attributes, setAttributes, className, isSelected }) {
       <BlockConfigurationPanel
         icon={icon}
         setAttributes={setAttributes}
-        instruction={__('Select Block Type', 'web-stories')}
+        instruction={__(
+          'Embed a collection of your latest stories, select your own or enter an URL',
+          'web-stories'
+        )}
         columnCount={3}
         selectionOptions={BLOCK_TYPES}
         selectionType={'blockType'}
@@ -65,7 +68,7 @@ function WebStoriesEdit({ attributes, setAttributes, className, isSelected }) {
       <BlockConfigurationPanel
         icon={icon}
         setAttributes={setAttributes}
-        instruction={__('Select Block View Type', 'web-stories')}
+        instruction={__('Select an layout style', 'web-stories')}
         columnCount={4}
         selectionOptions={VIEW_TYPES}
         selectionType={'viewType'}

--- a/assets/src/web-stories-block/block/icons.js
+++ b/assets/src/web-stories-block/block/icons.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
  * WordPress dependencies
  */
 import { Circle, Path, Rect, SVG } from '@wordpress/components';
@@ -54,7 +59,7 @@ export const SELECTED_STORIES_BLOCK_ICON = (
     <Path
       d="M16 9.26315V16M16 22.7368V16M16 16H9.26315M16 16H22.7368"
       stroke="#347BB5"
-      stroke-width="2"
+      strokeWidth="2"
     />
   </SVG>
 );
@@ -81,16 +86,185 @@ export const EMBED_STORY_BLOCK_ICON = (
   </SVG>
 );
 
+const Icon = styled.svg`
+  .is-pressed & circle {
+    stroke: black;
+  }
+`;
+
 // Icons for view types.
 export const CAROUSEL_VIEW_TYPE_ICON = (
-  /* From https://material.io/tools/icons */
-  <SVG
+  <Icon
+    width="18"
+    height="14"
+    viewBox="0 0 18 14"
+    fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
   >
-    <Path d="M0 0h24v24H0z" fill="none" />
-    <Path d="M7 19h10V4H7v15zm-5-2h4V6H2v11zM18 6v11h4V6h-4z" />
+    <rect width="10" height="14" transform="matrix(1 0 0 -1 4 14)" />
+    <rect width="2" height="10" transform="matrix(1 0 0 -1 16 12)" />
+    <rect width="2" height="10" transform="matrix(1 0 0 -1 0 12)" />
+  </Icon>
+);
+
+export const CIRCLES_VIEW_TYPE_ICON = (
+  <Icon
+    width="23"
+    height="18"
+    viewBox="0 0 23 18"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <Circle r="3" transform="matrix(1 0 0 -1 20 9)" />
+    <Circle r="3" transform="matrix(1 0 0 -1 3 9)" />
+    <Circle
+      r="7.1"
+      transform="matrix(1 0 0 -1 12 9)"
+      stroke="white"
+      strokeWidth="2.2"
+    />
+  </Icon>
+);
+
+export const GRID_VIEW_TYPE_ICON = (
+  <Icon
+    width="12"
+    height="14"
+    viewBox="0 0 12 14"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect width="5" height="6" />
+    <rect y="8" width="5" height="6" />
+    <rect x="7" width="5" height="6" />
+    <rect x="7" y="8" width="5" height="6" />
+  </Icon>
+);
+
+export const LIST_VIEW_TYPE_ICON = (
+  <Icon
+    width="12"
+    height="13"
+    viewBox="0 0 12 13"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect width="12" height="3" />
+    <rect y="5" width="12" height="3" />
+    <rect y="10" width="12" height="3" />
+  </Icon>
+);
+
+// Configuration panel view type icons.
+export const BOX_CAROUSEL_CONFIG_ICON = (
+  <SVG
+    width="26"
+    height="20"
+    viewBox="0 0 26 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <Rect x="7" y="1" width="12" height="18" stroke="#347BB5" strokeWidth="2" />
+    <Rect x="24" y="2" width="2" height="16" fill="#347BB5" />
+    <Rect y="2" width="2" height="16" fill="#347BB5" />
+  </SVG>
+);
+
+export const LIST_VIEW_CONFIG_ICON = (
+  <SVG
+    width="22"
+    height="26"
+    viewBox="0 0 22 26"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <Rect x="1" y="1" width="20" height="4" stroke="#347BB5" strokeWidth="2" />
+    <Rect x="1" y="11" width="20" height="4" stroke="#347BB5" strokeWidth="2" />
+    <Rect x="1" y="21" width="20" height="4" stroke="#347BB5" strokeWidth="2" />
+  </SVG>
+);
+
+export const CIRCLE_CAROUSEL_CONFIG_ICON = (
+  <SVG
+    width="42"
+    height="24"
+    viewBox="0 0 42 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx="21"
+      cy="12"
+      r="11"
+      fill="white"
+      stroke="#347BB5"
+      strokeWidth="2"
+    />
+    <mask id="path-2-inside-1" fill="white">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M34.8033 17.8807C35.5736 16.0749 36 14.0872 36 12C36 9.91277 35.5736 7.9251 34.8033 6.11933C35.19 6.04108 35.5902 6 36 6C39.3137 6 42 8.68629 42 12C42 15.3137 39.3137 18 36 18C35.5902 18 35.19 17.9589 34.8033 17.8807Z"
+      />
+    </mask>
+    <path
+      d="M34.8033 17.8807L32.9637 17.0959L32.0005 19.354L34.4066 19.8409L34.8033 17.8807ZM34.8033 6.11933L34.4066 4.15908L32.0005 4.64604L32.9637 6.90407L34.8033 6.11933ZM34 12C34 13.8126 33.6301 15.5337 32.9637 17.0959L36.643 18.6654C37.5172 16.6161 38 14.3618 38 12H34ZM32.9637 6.90407C33.6301 8.46629 34 10.1874 34 12H38C38 9.63816 37.5172 7.38392 36.643 5.3346L32.9637 6.90407ZM35.2001 8.07959C35.4569 8.02761 35.7242 8 36 8V4C35.4562 4 34.9232 4.05454 34.4066 4.15908L35.2001 8.07959ZM36 8C38.2091 8 40 9.79086 40 12H44C44 7.58172 40.4182 4 36 4V8ZM40 12C40 14.2091 38.2091 16 36 16V20C40.4182 20 44 16.4183 44 12H40ZM36 16C35.7242 16 35.4569 15.9724 35.2001 15.9204L34.4066 19.8409C34.9231 19.9455 35.4562 20 36 20V16Z"
+      fill="#347BB5"
+      mask="url(#path-2-inside-1)"
+    />
+    <mask id="path-4-inside-2" fill="white">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M7.19661 6.11934C6.80993 6.04108 6.40976 6 6 6C2.68629 6 0 8.68629 0 12C0 15.3137 2.68629 18 6 18C6.40976 18 6.80993 17.9589 7.19661 17.8807C6.42631 16.0749 6 14.0872 6 12C6 9.91277 6.42631 7.92511 7.19661 6.11934Z"
+      />
+    </mask>
+    <path
+      d="M7.19661 6.11934L9.03623 6.90407L9.99945 4.64604L7.59334 4.15908L7.19661 6.11934ZM7.19661 17.8807L7.59334 19.8409L9.99945 19.354L9.03623 17.0959L7.19661 17.8807ZM6 8C6.27577 8 6.54305 8.02761 6.79988 8.07959L7.59334 4.15908C7.07681 4.05454 6.54375 4 6 4V8ZM2 12C2 9.79086 3.79086 8 6 8V4C1.58172 4 -2 7.58172 -2 12H2ZM6 16C3.79086 16 2 14.2091 2 12H-2C-2 16.4183 1.58172 20 6 20V16ZM6.79988 15.9204C6.54305 15.9724 6.27577 16 6 16V20C6.54375 20 7.07681 19.9455 7.59334 19.8409L6.79988 15.9204ZM9.03623 17.0959C8.36982 15.5337 8 13.8126 8 12H4C4 14.3618 4.4828 16.6161 5.35699 18.6654L9.03623 17.0959ZM8 12C8 10.1874 8.36982 8.46629 9.03623 6.90407L5.35699 5.3346C4.4828 7.38392 4 9.63816 4 12H8Z"
+      fill="#347BB5"
+      mask="url(#path-4-inside-2)"
+    />
+  </SVG>
+);
+
+export const GRID_VIEW_CONFIG_ICON = (
+  <SVG
+    width="20"
+    height="27"
+    viewBox="0 0 20 27"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect
+      x="1"
+      y="1"
+      width="6.46154"
+      height="9.53846"
+      stroke="#347BB5"
+      strokeWidth="2"
+    />
+    <rect
+      x="1"
+      y="15.6154"
+      width="6.46154"
+      height="9.53846"
+      stroke="#347BB5"
+      strokeWidth="2"
+    />
+    <rect
+      x="12.5385"
+      y="1"
+      width="6.46154"
+      height="9.53846"
+      stroke="#347BB5"
+      strokeWidth="2"
+    />
+    <rect
+      x="12.5385"
+      y="15.6154"
+      width="6.46154"
+      height="9.53846"
+      stroke="#347BB5"
+      strokeWidth="2"
+    />
   </SVG>
 );

--- a/includes/Block/Web_Stories_Block.php
+++ b/includes/Block/Web_Stories_Block.php
@@ -182,6 +182,7 @@ class Web_Stories_Block {
 			'config'     => [
 				'maxNumOfStories' => $this->max_num_of_stories,
 				'editStoryURL'    => $edit_story_url,
+				'archiveURL'      => get_post_type_archive_link( $rest_base ),
 				'api'             => [
 					'stories' => sprintf( '/web-stories/v1/%s', $rest_base ),
 					'users'   => '/web-stories/v1/users/',

--- a/includes/assets/stories.css
+++ b/includes/assets/stories.css
@@ -22,7 +22,12 @@
 .web-stories-list .web-stories-list__story-placeholder {
   background-size: cover;
   background-position: center;
-  height: 430px;
+}
+
+.web-stories-list .web-stories-list__story-placeholder::after {
+  content: '';
+  display: block;
+  padding-bottom: 166%;
 }
 
 /* story content overlay styles */
@@ -60,11 +65,6 @@
   grid-gap: 32px;
 }
 
-.web-stories-list.is-view-type-grid .web-stories-list__story-wrapper {
-  margin-left: auto;
-  margin-right: auto;
-}
-
 /* List View Styles */
 .web-stories-list.is-view-type-list .story-content-overlay {
   position: relative;
@@ -92,8 +92,12 @@
 .web-stories-list.is-view-type-list .web-stories-list__story-placeholder {
   height: auto;
   flex-basis: 40%;
-  padding-top: 17%;
   flex-shrink: 0;
+}
+
+.web-stories-list.is-view-type-list
+  .web-stories-list__story-placeholder::after {
+  padding-bottom: 75%;
 }
 
 /* Circles View Styles */


### PR DESCRIPTION
## Summary

Updates icons for the blockType and layout selection buttons.

## User-facing changes

- Updates user facing panel and layout order.

- ### BlockType selection panel:
  - Before
![Screenshot 2020-12-28 at 5 21 11 PM](https://user-images.githubusercontent.com/6906779/103212664-75973100-4931-11eb-9e64-b6b770d8b576.png)

  - Now
![Screenshot 2020-12-25 at 12 47 51 PM](https://user-images.githubusercontent.com/6906779/103212677-7cbe3f00-4931-11eb-88c8-12f7f98232b5.png)

- ### Layout selection panel:
  - Before
![Screenshot 2020-12-28 at 5 21 18 PM](https://user-images.githubusercontent.com/6906779/103212772-d0308d00-4931-11eb-9f25-90b9d37eaed5.png)

  - Now
![Screenshot 2020-12-28 at 5 29 37 PM](https://user-images.githubusercontent.com/6906779/103212982-5351e300-4932-11eb-9e5a-3e9316b127ca.png)

 