### PR TITLE
Add circle size field support

### DIFF
--- a/assets/src/tinymce/__tests__/components/__snapshots__/Modal.test.js.snap
+++ b/assets/src/tinymce/__tests__/components/__snapshots__/Modal.test.js.snap
@@ -37,6 +37,19 @@ exports[`TinyMCE Controls Modal modal is opened and view is circle 1`] = `
     min={1}
     onChange={[Function]}
   />
+  <Range
+    label="Circle Size"
+    max={200}
+    min={80}
+    onChange={[Function]}
+    step={5}
+  />
+  <Range
+    label="Number of Columns"
+    max={4}
+    min={1}
+    onChange={[Function]}
+  />
   <Select
     label="Select Order"
     onChange={[Function]}

--- a/assets/src/tinymce/components/Modal.js
+++ b/assets/src/tinymce/components/Modal.js
@@ -185,6 +185,7 @@ WebStoriesModal.propTypes = {
     columns: PropTypes.number,
     order: PropTypes.string,
     view: PropTypes.string,
+    circle_size: PropTypes.number,
   }),
   prepareShortCode: PropTypes.func,
 };

--- a/assets/src/tinymce/components/Modal.js
+++ b/assets/src/tinymce/components/Modal.js
@@ -108,8 +108,7 @@ const WebStoriesModal = (props) => {
               step={5}
               onChange={(size) =>
                 updateViewSettings({
-                  // eslint-disable-next-line radix
-                  fieldObj: parseInt(size, 10),
+                  fieldObj: parseInt(size),
                   field: 'circle_size',
                 })
               }

--- a/assets/src/tinymce/components/Modal.js
+++ b/assets/src/tinymce/components/Modal.js
@@ -51,6 +51,7 @@ const WebStoriesModal = (props) => {
     excerpt,
     image_align,
     archive_link,
+    circle_size,
   } = settings;
   const { views, orderlist } = webStoriesData;
 
@@ -97,6 +98,23 @@ const WebStoriesModal = (props) => {
               updateViewSettings({ fieldObj: items, field: 'number' });
             }}
           />
+
+          {isCircleView() && (
+            <RangeControl
+              label={__('Circle Size', 'web-stories')}
+              value={circle_size}
+              min={80}
+              max={200}
+              step={5}
+              onChange={(size) =>
+                updateViewSettings({
+                  // eslint-disable-next-line radix
+                  fieldObj: parseInt(size, 10),
+                  field: 'circle_size',
+                })
+              }
+            />
+          )}
 
           {!isCircleView() && (
             <RangeControl

--- a/assets/src/tinymce/utils/index.js
+++ b/assets/src/tinymce/utils/index.js
@@ -103,6 +103,7 @@ export const setDefaultStateSetting = () => {
       columns: 1,
       view: viewValue,
       order: orderlist ? 'latest' : orderlist[0].value,
+      circle_size: 150,
     };
   });
 

--- a/assets/src/widget/stories-widget.js
+++ b/assets/src/widget/stories-widget.js
@@ -44,25 +44,21 @@ const reactiveWidget = function (target, reset = false) {
     if (field && fieldWrapper) {
       const field_type = field.getAttribute('type');
 
-      switch (field_type) {
-        case 'checkbox':
-          if (reset) {
-            field.checked = false;
-          }
-          /**
-           * If this is readonly field.
-           * Assign the value automatically and hide it afterward.
-           */
-          if (value.readonly) {
-            field.checked = value.show;
-          }
+      if ('checkbox' === field_type) {
+        if (reset) {
+          field.checked = false;
+        }
+        /**
+         * If this is readonly field.
+         * Assign the value automatically and hide it afterward.
+         */
+        if (value.readonly) {
+          field.checked = value.show;
+        }
 
-          fieldWrapper.style.display = value.readonly ? 'none' : 'block';
-          break;
-
-        default:
-          fieldWrapper.style.display = value.show ? 'block' : 'none';
-          break;
+        fieldWrapper.style.display = value.readonly ? 'none' : 'block';
+      } else {
+        fieldWrapper.style.display = value.show ? 'block' : 'none';
       }
     }
   }

--- a/assets/src/widget/stories-widget.js
+++ b/assets/src/widget/stories-widget.js
@@ -61,11 +61,7 @@ const reactiveWidget = function (target, reset = false) {
           break;
 
         default:
-          if (value.show) {
-            fieldWrapper.style.display = 'block';
-          } else {
-            fieldWrapper.style.display = 'none';
-          }
+          fieldWrapper.style.display = value.show ? 'block' : 'none';
           break;
       }
     }

--- a/assets/src/widget/stories-widget.js
+++ b/assets/src/widget/stories-widget.js
@@ -40,18 +40,34 @@ const reactiveWidget = function (target, reset = false) {
   for (const [key, value] of Object.entries(state)) {
     const field = widget.querySelector(`.${key}.stories-widget-field`);
     const fieldWrapper = widget.querySelector(`.${key}_wrapper`);
-    if (field && fieldWrapper && 'checkbox' === field.getAttribute('type')) {
-      if (reset) {
-        field.checked = false;
+
+    if (field && fieldWrapper) {
+      const field_type = field.getAttribute('type');
+
+      switch (field_type) {
+        case 'checkbox':
+          if (reset) {
+            field.checked = false;
+          }
+          /**
+           * If this is readonly field.
+           * Assign the value automatically and hide it afterward.
+           */
+          if (value.readonly) {
+            field.checked = value.show;
+          }
+
+          fieldWrapper.style.display = value.readonly ? 'none' : 'block';
+          break;
+
+        default:
+          if (value.show) {
+            fieldWrapper.style.display = 'block';
+          } else {
+            fieldWrapper.style.display = 'none';
+          }
+          break;
       }
-      /**
-       * If this is readonly field.
-       * Assign the value automatically and hide it afterward.
-       */
-      if (value.readonly) {
-        field.checked = value.show;
-      }
-      fieldWrapper.style.display = value.readonly ? 'none' : 'block';
     }
   }
 };

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -205,6 +205,32 @@ class Customizer {
 		);
 
 		$wp_customize->add_setting(
+			self::STORY_OPTION . '[circle_size]',
+			[
+				'default' => $theme_support['default-circle-size'],
+				'type'    => 'option',
+			]
+		);
+
+		$wp_customize->add_control(
+			self::STORY_OPTION . '[circle_size]',
+			[
+				'section'         => self::SECTION_SLUG,
+				'label'           => __( 'Circle Size', 'web-stories' ),
+				'type'            => 'number',
+				'choices'         => $this->get_order_choices( $theme_support['order'] ),
+				'input_attrs'     => [
+					'min'  => 80,
+					'max'  => 200,
+					'step' => 5,
+				],
+				'active_callback' => function() {
+					return $this->is_view_type( 'circles' );
+				},
+			]
+		);
+
+		$wp_customize->add_setting(
 			self::STORY_OPTION . '[list_view_image_alignment]',
 			[
 				'type'    => 'option',
@@ -477,6 +503,7 @@ class Customizer {
 			'stories_archive_label' => $theme_support['stories-archive-label'],
 			'show_story_poster'     => $theme_support['show-story-poster-default'],
 			'number_of_columns'     => $theme_support['grid-columns-default'],
+			'circle_size'           => $theme_support['default-circle-size'],
 		];
 
 		$query_arguments = [

--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -207,7 +207,7 @@ class Customizer {
 		$wp_customize->add_setting(
 			self::STORY_OPTION . '[circle_size]',
 			[
-				'default' => $theme_support['default-circle-size'],
+				'default' => $theme_support['circle-size-default'],
 				'type'    => 'option',
 			]
 		);
@@ -218,7 +218,6 @@ class Customizer {
 				'section'         => self::SECTION_SLUG,
 				'label'           => __( 'Circle Size', 'web-stories' ),
 				'type'            => 'number',
-				'choices'         => $this->get_order_choices( $theme_support['order'] ),
 				'input_attrs'     => [
 					'min'  => 80,
 					'max'  => 200,
@@ -503,7 +502,7 @@ class Customizer {
 			'stories_archive_label' => $theme_support['stories-archive-label'],
 			'show_story_poster'     => $theme_support['show-story-poster-default'],
 			'number_of_columns'     => $theme_support['grid-columns-default'],
-			'circle_size'           => $theme_support['default-circle-size'],
+			'circle_size'           => $theme_support['circle-size-default'],
 		];
 
 		$query_arguments = [

--- a/includes/Stories_Renderer/FieldState/BaseFieldState.php
+++ b/includes/Stories_Renderer/FieldState/BaseFieldState.php
@@ -146,7 +146,7 @@ class BaseFieldState implements FieldState {
 			[
 				'label'    => __( 'Circle Size', 'web-stories' ),
 				'show'     => false,
-				'readonly' => false,
+				'readonly' => true,
 			]
 		);
 	}

--- a/includes/Stories_Renderer/FieldState/BaseFieldState.php
+++ b/includes/Stories_Renderer/FieldState/BaseFieldState.php
@@ -137,6 +137,21 @@ class BaseFieldState implements FieldState {
 	}
 
 	/**
+	 * Circle size field.
+	 *
+	 * @return BaseField
+	 */
+	public function circle_size() {
+		return new BaseField(
+			[
+				'label'    => __( 'Circle Size', 'web-stories' ),
+				'show'     => false,
+				'readonly' => false,
+			]
+		);
+	}
+
+	/**
 	 * Prepare a field object.
 	 *
 	 * @param array $args Arguments to build field.

--- a/includes/Stories_Renderer/FieldState/CircleView.php
+++ b/includes/Stories_Renderer/FieldState/CircleView.php
@@ -98,4 +98,21 @@ final class CircleView extends BaseFieldState {
 		);
 	}
 
+	/**
+	 * Circle size field.
+	 *
+	 * @return BaseField
+	 */
+	public function circle_size() {
+		$label = parent::circle_size()->label();
+
+		return $this->prepare_field(
+			[
+				'label'    => $label,
+				'show'     => true,
+				'readonly' => false,
+			]
+		);
+	}
+
 }

--- a/includes/Traits/ThemeSupport.php
+++ b/includes/Traits/ThemeSupport.php
@@ -58,6 +58,7 @@ trait ThemeSupport {
 			'stories-archive-link'      => true,
 			'stories-archive-label'     => __( 'View all stories', 'web-stories' ),
 			'number-of-stories'         => 10,
+			'default-circle-size'       => 150,
 			'order'                     => get_stories_order(),
 			'order-default'             => 'latest',
 			'show-story-poster-default' => true,

--- a/includes/Traits/ThemeSupport.php
+++ b/includes/Traits/ThemeSupport.php
@@ -58,7 +58,7 @@ trait ThemeSupport {
 			'stories-archive-link'      => true,
 			'stories-archive-label'     => __( 'View all stories', 'web-stories' ),
 			'number-of-stories'         => 10,
-			'default-circle-size'       => 150,
+			'circle-size-default'       => 150,
 			'order'                     => get_stories_order(),
 			'order-default'             => 'latest',
 			'show-story-poster-default' => true,

--- a/includes/Widgets/Stories.php
+++ b/includes/Widgets/Stories.php
@@ -166,7 +166,7 @@ class Stories extends WP_Widget {
 			[
 				'id'            => 'circle-size',
 				'name'          => 'circle_size',
-				'label'         => __( 'Circle size', 'web-stories' ),
+				'label'         => __( 'Circle Size', 'web-stories' ),
 				'type'          => 'number',
 				'classname'     => 'widefat circle_size stories-widget-field',
 				'wrapper_class' => 'circle_size_wrapper',

--- a/includes/Widgets/Stories.php
+++ b/includes/Widgets/Stories.php
@@ -91,6 +91,7 @@ class Stories extends WP_Widget {
 			'show_excerpt'              => (bool) $instance['show_excerpt'],
 			'list_view_image_alignment' => ( (bool) $instance['image_align_right'] ) ? 'right' : 'left',
 			'show_stories_archive_link' => (bool) $instance['archive_link'],
+			'circle_size'				=> $instance['circle_size'],
 		];
 
 		$story_args = [
@@ -124,6 +125,7 @@ class Stories extends WP_Widget {
 		$archive_link      = ! empty( $instance['archive_link'] ) ? (int) $instance['archive_link'] : '';
 		$image_align       = ! empty( $instance['image_align_right'] ) ? (int) $instance['image_align_right'] : '';
 		$number            = ! empty( $instance['number'] ) ? (int) $instance['number'] : 5;
+		$circle_size	   = ! empty( $instance['circle_size'] ) ? (int) $instance['circle_size'] : 100;
 
 		$this->input(
 			[
@@ -157,6 +159,24 @@ class Stories extends WP_Widget {
 				'wrapper_class' => 'number-stories_wrapper',
 				'value'         => $number,
 				'label_before'  => true,
+			]
+		);
+
+		$this->input(
+			[
+				'id'            => 'circle-size',
+				'name'          => 'circle_size',
+				'label'         => __( 'Circle size', 'web-stories' ),
+				'type'          => 'number',
+				'classname'     => 'widefat circle_size stories-widget-field',
+				'wrapper_class' => 'circle_size_wrapper',
+				'value'         => $circle_size,
+				'label_before'  => true,
+				'attributes'	=> [
+					'min'  => 80,
+					'max'  => 200,
+					'step' => 5,
+				],
 			]
 		);
 
@@ -256,6 +276,7 @@ class Stories extends WP_Widget {
 		$instance['archive_link']      = ( isset( $new_instance['archive_link'] ) ) ? 1 : '';
 		$instance['image_align_right'] = ( isset( $new_instance['image_align_right'] ) ) ? 1 : '';
 		$instance['number']            = min( absint( $new_instance['number'] ), 20 );
+		$instance['circle_size']	   = min( absint( $new_instance['circle_size'] ), 200 );
 
 		return $instance;
 	}
@@ -375,6 +396,14 @@ class Stories extends WP_Widget {
 			if ( $args['label_before'] ) {
 				echo $label;
 			}
+
+			$extra_attrs = '';
+
+			if ( ! empty( $args['attributes'] ) && is_array( $args['attributes'] ) ) {
+				foreach ( $args['attributes'] as $attr_key => $attr_val ) {
+					$extra_attrs .= sprintf( ' %1s=%2s', $attr_key, $attr_val );
+				}
+			}
 			?>
 
 			<input
@@ -388,6 +417,7 @@ class Stories extends WP_Widget {
 					checked( 1, $args['value'], true );
 				}
 				?>
+				<?php echo $extra_attrs; ?>
 			/>
 
 			<?php

--- a/includes/Widgets/Stories.php
+++ b/includes/Widgets/Stories.php
@@ -401,7 +401,7 @@ class Stories extends WP_Widget {
 
 			if ( ! empty( $args['attributes'] ) && is_array( $args['attributes'] ) ) {
 				foreach ( $args['attributes'] as $attr_key => $attr_val ) {
-					$extra_attrs .= sprintf( ' %1s=%2s', $attr_key, $attr_val );
+					$extra_attrs .= sprintf( ' %1s=%2s', $attr_key, esc_attr( $attr_val ) );
 				}
 			}
 			?>

--- a/includes/Widgets/Stories.php
+++ b/includes/Widgets/Stories.php
@@ -91,7 +91,7 @@ class Stories extends WP_Widget {
 			'show_excerpt'              => (bool) $instance['show_excerpt'],
 			'list_view_image_alignment' => ( (bool) $instance['image_align_right'] ) ? 'right' : 'left',
 			'show_stories_archive_link' => (bool) $instance['archive_link'],
-			'circle_size'				=> $instance['circle_size'],
+			'circle_size'               => $instance['circle_size'],
 		];
 
 		$story_args = [
@@ -125,7 +125,7 @@ class Stories extends WP_Widget {
 		$archive_link      = ! empty( $instance['archive_link'] ) ? (int) $instance['archive_link'] : '';
 		$image_align       = ! empty( $instance['image_align_right'] ) ? (int) $instance['image_align_right'] : '';
 		$number            = ! empty( $instance['number'] ) ? (int) $instance['number'] : 5;
-		$circle_size	   = ! empty( $instance['circle_size'] ) ? (int) $instance['circle_size'] : 100;
+		$circle_size       = ! empty( $instance['circle_size'] ) ? (int) $instance['circle_size'] : 100;
 
 		$this->input(
 			[
@@ -172,7 +172,7 @@ class Stories extends WP_Widget {
 				'wrapper_class' => 'circle_size_wrapper',
 				'value'         => $circle_size,
 				'label_before'  => true,
-				'attributes'	=> [
+				'attributes'    => [
 					'min'  => 80,
 					'max'  => 200,
 					'step' => 5,
@@ -276,7 +276,7 @@ class Stories extends WP_Widget {
 		$instance['archive_link']      = ( isset( $new_instance['archive_link'] ) ) ? 1 : '';
 		$instance['image_align_right'] = ( isset( $new_instance['image_align_right'] ) ) ? 1 : '';
 		$instance['number']            = min( absint( $new_instance['number'] ), 20 );
-		$instance['circle_size']	   = min( absint( $new_instance['circle_size'] ), 200 );
+		$instance['circle_size']       = min( absint( $new_instance['circle_size'] ), 200 );
 
 		return $instance;
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -103,6 +103,7 @@ function fields_states() {
 		'excerpt',
 		'sharp_corners',
 		'archive_link',
+		'circle_size',
 	];
 
 	$field_states = [];

--- a/tests/phpunit/tests/Customizer.php
+++ b/tests/phpunit/tests/Customizer.php
@@ -177,8 +177,8 @@ class Customizer extends \WP_UnitTestCase {
 			[
 				'story-options[circle_size]',
 				[
-					'default'           => 150,
-					'type'              => 'option',
+					'default' => 150,
+					'type'    => 'option',
 				],
 			],
 			[

--- a/tests/phpunit/tests/Customizer.php
+++ b/tests/phpunit/tests/Customizer.php
@@ -80,6 +80,7 @@ class Customizer extends \WP_UnitTestCase {
 				'stories-archive-link'      => true,
 				'stories-archive-label'     => 'View all stories',
 				'number-of-stories'         => 5,
+				'default-circle-size'       => 150,
 				'order'                     => [ 'alphabetical', 'reverse-alphabetical', 'latest', 'oldest' ],
 				'order-default'             => 'oldest',
 				'show-story-poster-default' => true,
@@ -124,7 +125,7 @@ class Customizer extends \WP_UnitTestCase {
 	 */
 	public function test_customizer_settings_added() {
 		$this->add_web_stories_theme_support();
-		$this->customizer_mock->expects( $this->exactly( 12 ) )->method( 'add_setting' );
+		$this->customizer_mock->expects( $this->exactly( 13 ) )->method( 'add_setting' );
 		$this->customizer->register_customizer_settings( $this->customizer_mock );
 	}
 
@@ -133,7 +134,7 @@ class Customizer extends \WP_UnitTestCase {
 	 */
 	public function test_customizer_show_stories_settings_added() {
 		$this->add_web_stories_theme_support();
-		$this->customizer_mock->expects( $this->exactly( 12 ) )->
+		$this->customizer_mock->expects( $this->exactly( 13 ) )->
 		method( 'add_setting' )->
 		withConsecutive(
 			[
@@ -171,6 +172,13 @@ class Customizer extends \WP_UnitTestCase {
 				[
 					'default' => 'oldest',
 					'type'    => 'option',
+				],
+			],
+			[
+				'story-options[circle_size]',
+				[
+					'default'           => 150,
+					'type'              => 'option',
 				],
 			],
 			[
@@ -289,6 +297,7 @@ class Customizer extends \WP_UnitTestCase {
 			'stories-archive-link'      => true,
 			'stories-archive-label'     => __( 'View all stories', 'web-stories' ),
 			'number-of-stories'         => 10,
+			'default-circle-size'       => 150,
 			'order'                     => [
 				'latest'               => __( 'Latest', 'web-stories' ),
 				'oldest'               => __( 'Oldest', 'web-stories' ),
@@ -324,6 +333,7 @@ class Customizer extends \WP_UnitTestCase {
 				'stories-archive-link'      => true,
 				'stories-archive-label'     => 'View all stories',
 				'number-of-stories'         => 5,
+				'default-circle-size'       => 150,
 				'order'                     => [ 'alphabetical', 'reverse-alphabetical', 'latest', 'oldest' ],
 				'order-default'             => 'oldest',
 				'show-story-poster-default' => true,

--- a/tests/phpunit/tests/Customizer.php
+++ b/tests/phpunit/tests/Customizer.php
@@ -297,7 +297,7 @@ class Customizer extends \WP_UnitTestCase {
 			'stories-archive-link'      => true,
 			'stories-archive-label'     => __( 'View all stories', 'web-stories' ),
 			'number-of-stories'         => 10,
-			'default-circle-size'       => 150,
+			'circle-size-default'       => 150,
 			'order'                     => [
 				'latest'               => __( 'Latest', 'web-stories' ),
 				'oldest'               => __( 'Oldest', 'web-stories' ),

--- a/tests/phpunit/tests/Widgets/Stories.php
+++ b/tests/phpunit/tests/Widgets/Stories.php
@@ -91,10 +91,11 @@ class Stories extends \WP_UnitTestCase {
 	 */
 	public function test_update() {
 		$new_instance = [
-			'title'      => '<p>Test Stories</p>',
-			'view-type'  => 'list',
-			'show_title' => '',
-			'number'     => 100,
+			'title'       => '<p>Test Stories</p>',
+			'view-type'   => 'list',
+			'show_title'  => '',
+			'number'      => 100,
+			'circle_size' => 150,
 		];
 
 		$old_instance = [];
@@ -109,6 +110,7 @@ class Stories extends \WP_UnitTestCase {
 			'archive_link'      => '',
 			'image_align_right' => '',
 			'number'            => 20,
+			'circle_size'       => 150,
 		];
 
 		$instance = self::$testee->update( $new_instance, $old_instance );


### PR DESCRIPTION
## Context

Add `Circle Size` field to Customizer, Widget, TinyMCE and Shortcode.

## Summary

Circle Size field was added in blocks, but the support was not present in Customizer, Widget, TinyMCE.

Support for these areas has been added for Circle Size.

## Relevant Technical Choices

Circle size will have minimum value of `80` and maximum value of `200`

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Users would be able to enter circle size for customizer, tinyMCE and web stories widget.
