### PR TITLE
Core Theme Styles

### DIFF
--- a/assets/src/web-stories-block/css/common.css
+++ b/assets/src/web-stories-block/css/common.css
@@ -1,5 +1,10 @@
 /* Web Stories: Common block styles */
-.web-stories-list__inner-wrapper {
+.web-stories-list.wp-block-web-stories-list {
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.web-stories-list.is-carousel .web-stories-list__inner-wrapper {
   max-width: max-content;
   margin: 0 auto;
   position: relative;

--- a/assets/src/web-stories-block/css/common.css
+++ b/assets/src/web-stories-block/css/common.css
@@ -1,9 +1,4 @@
 /* Web Stories: Common block styles */
-.web-stories-list.wp-block-web-stories-list {
-  margin-top: 24px;
-  margin-bottom: 24px;
-}
-
 .web-stories-list.is-carousel .web-stories-list__inner-wrapper {
   max-width: max-content;
   margin: 0 auto;

--- a/assets/src/web-stories-block/css/core-themes.css
+++ b/assets/src/web-stories-block/css/core-themes.css
@@ -1,9 +1,0 @@
-@import 'core-themes/twenty-twenty-one.css';
-@import 'core-themes/twenty-twenty.css';
-@import 'core-themes/twenty-seventeen.css';
-@import 'core-themes/twenty-sixteen.css';
-@import 'core-themes/twenty-fifteen.css';
-@import 'core-themes/twenty-fourteen.css';
-@import 'core-themes/twenty-twelve.css';
-@import 'core-themes/twenty-eleven.css';
-@import 'core-themes/twenty-ten.css';

--- a/assets/src/web-stories-block/css/core-themes.css
+++ b/assets/src/web-stories-block/css/core-themes.css
@@ -1,0 +1,9 @@
+@import 'core-themes/twenty-twenty-one.css';
+@import 'core-themes/twenty-twenty.css';
+@import 'core-themes/twenty-seventeen.css';
+@import 'core-themes/twenty-sixteen.css';
+@import 'core-themes/twenty-fifteen.css';
+@import 'core-themes/twenty-fourteen.css';
+@import 'core-themes/twenty-twelve.css';
+@import 'core-themes/twenty-eleven.css';
+@import 'core-themes/twenty-ten.css';

--- a/assets/src/web-stories-block/css/core-themes/twenty-eleven.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-eleven.css
@@ -1,4 +1,4 @@
-.is-showing-header-stories > .web-stories-list {
+.web-stories-theme-header-section .web-stories-list {
   max-width: 1000px;
   margin: 0 auto;
   border-bottom: none;

--- a/assets/src/web-stories-block/css/core-themes/twenty-eleven.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-eleven.css
@@ -1,4 +1,4 @@
-.has-web-stories-support.twenty-eleven > .web-stories-list {
+.is-showing-header-stories > .web-stories-list {
   max-width: 1000px;
   margin: 0 auto;
   border-bottom: none;

--- a/assets/src/web-stories-block/css/core-themes/twenty-eleven.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-eleven.css
@@ -1,0 +1,5 @@
+.has-web-stories-support.twenty-eleven > .web-stories-list {
+  max-width: 1000px;
+  margin: 0 auto;
+  border-bottom: none;
+}

--- a/assets/src/web-stories-block/css/core-themes/twenty-fifteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-fifteen.css
@@ -1,0 +1,25 @@
+.has-web-stories-support.twenty-fifteen
+  > .web-stories-list
+  .web-stories-list__archive-link
+  a {
+  text-decoration: underline;
+}
+
+@media screen and (min-width: 59.6875em) {
+  .has-web-stories-support.twenty-fifteen
+    > .web-stories-list
+    .web-stories-list__inner-wrapper {
+    margin: 0 8.3333%;
+  }
+
+  .has-web-stories-support.twenty-fifteen .site-main {
+    padding-top: 0;
+  }
+
+  .has-web-stories-support.twenty-fifteen > .web-stories-list {
+    display: block;
+    margin-left: 29.9118%;
+    width: 68.5882%;
+    border-bottom: none;
+  }
+}

--- a/assets/src/web-stories-block/css/core-themes/twenty-fifteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-fifteen.css
@@ -1,4 +1,4 @@
-.has-web-stories-support.twenty-fifteen
+.is-showing-header-stories
   > .web-stories-list
   .web-stories-list__archive-link
   a {
@@ -6,17 +6,17 @@
 }
 
 @media screen and (min-width: 59.6875em) {
-  .has-web-stories-support.twenty-fifteen
+  .is-showing-header-stories
     > .web-stories-list
     .web-stories-list__inner-wrapper {
     margin: 0 8.3333%;
   }
 
-  .has-web-stories-support.twenty-fifteen .site-main {
+  .is-showing-header-stories .site-main {
     padding-top: 0;
   }
 
-  .has-web-stories-support.twenty-fifteen > .web-stories-list {
+  .is-showing-header-stories > .web-stories-list {
     display: block;
     margin-left: 29.9118%;
     width: 68.5882%;

--- a/assets/src/web-stories-block/css/core-themes/twenty-fifteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-fifteen.css
@@ -1,13 +1,13 @@
-.is-showing-header-stories
-  > .web-stories-list
+.web-stories-theme-header-section
+  .web-stories-list
   .web-stories-list__archive-link
   a {
   text-decoration: underline;
 }
 
 @media screen and (min-width: 59.6875em) {
-  .is-showing-header-stories
-    > .web-stories-list
+  .web-stories-theme-header-section
+    .web-stories-list
     .web-stories-list__inner-wrapper {
     margin: 0 8.3333%;
   }
@@ -16,7 +16,7 @@
     padding-top: 0;
   }
 
-  .is-showing-header-stories > .web-stories-list {
+  .web-stories-theme-header-section .web-stories-list {
     display: block;
     margin-left: 29.9118%;
     width: 68.5882%;

--- a/assets/src/web-stories-block/css/core-themes/twenty-fifteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-fifteen.css
@@ -12,7 +12,7 @@
     margin: 0 8.3333%;
   }
 
-  .is-showing-header-stories .site-main {
+  .has-web-stories .site-main {
     padding-top: 0;
   }
 

--- a/assets/src/web-stories-block/css/core-themes/twenty-fourteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-fourteen.css
@@ -10,7 +10,7 @@
 }
 
 @media screen and (min-width: 783px) {
-  .is-showing-header-stories .site-main {
+  .has-web-stories .site-main {
     margin-top: 0;
   }
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-fourteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-fourteen.css
@@ -1,10 +1,10 @@
-.is-showing-header-stories > .web-stories-list {
+.web-stories-theme-header-section .web-stories-list {
   background: #000;
   border-bottom: none;
 }
 
-.is-showing-header-stories
-  > .web-stories-list
+.web-stories-theme-header-section
+  .web-stories-list
   .web-stories-list__story-content-overlay {
   color: #fff;
 }
@@ -16,7 +16,7 @@
 }
 
 @media screen and (min-width: 1008px) {
-  .is-showing-header-stories > .web-stories-list {
+  .web-stories-theme-header-section .web-stories-list {
     z-index: 1;
     width: 100%;
     max-width: 1260px;
@@ -24,7 +24,7 @@
     padding-top: 64px;
   }
 
-  .is-showing-header-stories > .web-stories-list.has-archive-link {
+  .web-stories-theme-header-section .web-stories-list.has-archive-link {
     padding-top: 92px;
   }
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-fourteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-fourteen.css
@@ -1,0 +1,27 @@
+@media screen and (min-width: 1008px) {
+  .has-web-stories-support.twenty-fourteen > .web-stories-list {
+    position: absolute;
+    z-index: 1;
+    width: 100%;
+    max-width: 1260px;
+  }
+
+  .has-web-stories-support.twenty-fourteen
+    > .web-stories-list
+    .web-stories-list__inner-wrapper {
+    margin-left: 182px;
+    max-width: 1037px;
+  }
+
+  .has-web-stories-support.twenty-fourteen .content-area {
+    padding-top: 142px;
+  }
+}
+
+@media screen and (min-width: 1080px) {
+  .has-web-stories-support.twenty-fourteen
+    > .web-stories-list
+    .web-stories-list__inner-wrapper {
+    margin-left: 222px;
+  }
+}

--- a/assets/src/web-stories-block/css/core-themes/twenty-fourteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-fourteen.css
@@ -1,27 +1,30 @@
-@media screen and (min-width: 1008px) {
-  .has-web-stories-support.twenty-fourteen > .web-stories-list {
-    position: absolute;
-    z-index: 1;
-    width: 100%;
-    max-width: 1260px;
-  }
+.is-showing-header-stories > .web-stories-list {
+  background: #000;
+  border-bottom: none;
+}
 
-  .has-web-stories-support.twenty-fourteen
-    > .web-stories-list
-    .web-stories-list__inner-wrapper {
-    margin-left: 182px;
-    max-width: 1037px;
-  }
+.is-showing-header-stories
+  > .web-stories-list
+  .web-stories-list__story-content-overlay {
+  color: #fff;
+}
 
-  .has-web-stories-support.twenty-fourteen .content-area {
-    padding-top: 142px;
+@media screen and (min-width: 783px) {
+  .is-showing-header-stories .site-main {
+    margin-top: 0;
   }
 }
 
-@media screen and (min-width: 1080px) {
-  .has-web-stories-support.twenty-fourteen
-    > .web-stories-list
-    .web-stories-list__inner-wrapper {
-    margin-left: 222px;
+@media screen and (min-width: 1008px) {
+  .is-showing-header-stories > .web-stories-list {
+    z-index: 1;
+    width: 100%;
+    max-width: 1260px;
+    padding-bottom: 22px;
+    padding-top: 64px;
+  }
+
+  .is-showing-header-stories > .web-stories-list.has-archive-link {
+    padding-top: 92px;
   }
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-seventeen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-seventeen.css
@@ -1,0 +1,43 @@
+.has-web-stories-support.twenty-seventeen > .web-stories-list {
+  z-index: 1;
+  background: rgba(0, 0, 0, 0.3);
+  border-bottom: none;
+  margin-top: 0;
+  position: relative;
+}
+
+.has-web-stories-support.twenty-seventeen > .web-stories-list.has-archive-link {
+  padding-top: 42px;
+  padding-bottom: 16px;
+}
+
+.has-web-stories-support.twenty-seventeen
+  > .web-stories-list
+  .web-stories-list__story-content-overlay {
+  color: #fff;
+}
+
+.has-web-stories-support.twenty-seventeen
+  > .web-stories-list
+  .web-stories-list__archive-link
+  a {
+  color: currentColor;
+}
+
+.has-web-stories-support.twenty-seventeen
+  > .web-stories-list
+  .web-stories-list__archive-link {
+  color: rgba(255, 255, 255, 0.8);
+  box-shadow: inset 0 -1px 0 #fff;
+  transition: color 80ms ease-in, box-shadow 130ms ease-in-out;
+}
+
+.has-web-stories-support.twenty-seventeen
+  > .web-stories-list
+  .web-stories-list__archive-link:hover,
+.has-web-stories-support.twenty-seventeen
+  > .web-stories-list
+  .web-stories-list__archive-link:focus {
+  color: #fff;
+  box-shadow: inset 0 0 0 rgb(0 0 0 / 0%), 0 3px 0 #fff;
+}

--- a/assets/src/web-stories-block/css/core-themes/twenty-seventeen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-seventeen.css
@@ -1,4 +1,4 @@
-.has-web-stories-support.twenty-seventeen > .web-stories-list {
+.is-showing-header-stories > .web-stories-list {
   z-index: 1;
   background: rgba(0, 0, 0, 0.3);
   border-bottom: none;
@@ -6,36 +6,34 @@
   position: relative;
 }
 
-.has-web-stories-support.twenty-seventeen > .web-stories-list.has-archive-link {
+.is-showing-header-stories > .web-stories-list.has-archive-link {
   padding-top: 42px;
   padding-bottom: 16px;
 }
 
-.has-web-stories-support.twenty-seventeen
+.is-showing-header-stories
   > .web-stories-list
   .web-stories-list__story-content-overlay {
   color: #fff;
 }
 
-.has-web-stories-support.twenty-seventeen
+.is-showing-header-stories
   > .web-stories-list
   .web-stories-list__archive-link
   a {
   color: currentColor;
 }
 
-.has-web-stories-support.twenty-seventeen
-  > .web-stories-list
-  .web-stories-list__archive-link {
+.is-showing-header-stories > .web-stories-list .web-stories-list__archive-link {
   color: rgba(255, 255, 255, 0.8);
   box-shadow: inset 0 -1px 0 #fff;
   transition: color 80ms ease-in, box-shadow 130ms ease-in-out;
 }
 
-.has-web-stories-support.twenty-seventeen
+.is-showing-header-stories
   > .web-stories-list
   .web-stories-list__archive-link:hover,
-.has-web-stories-support.twenty-seventeen
+.is-showing-header-stories
   > .web-stories-list
   .web-stories-list__archive-link:focus {
   color: #fff;

--- a/assets/src/web-stories-block/css/core-themes/twenty-seventeen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-seventeen.css
@@ -1,4 +1,4 @@
-.is-showing-header-stories > .web-stories-list {
+.web-stories-theme-header-section .web-stories-list {
   z-index: 1;
   background: rgba(0, 0, 0, 0.3);
   border-bottom: none;
@@ -6,35 +6,37 @@
   position: relative;
 }
 
-.is-showing-header-stories > .web-stories-list.has-archive-link {
+.web-stories-theme-header-section .web-stories-list.has-archive-link {
   padding-top: 42px;
   padding-bottom: 16px;
 }
 
-.is-showing-header-stories
-  > .web-stories-list
+.web-stories-theme-header-section
+  .web-stories-list
   .web-stories-list__story-content-overlay {
   color: #fff;
 }
 
-.is-showing-header-stories
-  > .web-stories-list
+.web-stories-theme-header-section
+  .web-stories-list
   .web-stories-list__archive-link
   a {
   color: currentColor;
 }
 
-.is-showing-header-stories > .web-stories-list .web-stories-list__archive-link {
+.web-stories-theme-header-section
+  .web-stories-list
+  .web-stories-list__archive-link {
   color: rgba(255, 255, 255, 0.8);
   box-shadow: inset 0 -1px 0 #fff;
   transition: color 80ms ease-in, box-shadow 130ms ease-in-out;
 }
 
-.is-showing-header-stories
-  > .web-stories-list
+.web-stories-theme-header-section
+  .web-stories-list
   .web-stories-list__archive-link:hover,
-.is-showing-header-stories
-  > .web-stories-list
+.web-stories-theme-header-section
+  .web-stories-list
   .web-stories-list__archive-link:focus {
   color: #fff;
   box-shadow: inset 0 0 0 rgb(0 0 0 / 0%), 0 3px 0 #fff;

--- a/assets/src/web-stories-block/css/core-themes/twenty-sixteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-sixteen.css
@@ -1,0 +1,38 @@
+.has-web-stories-support.twenty-sixteen > .web-stories-list {
+  border-bottom: none;
+}
+
+.has-web-stories-support.twenty-sixteen
+  > .web-stories-list
+  .web-stories-list__archive-link,
+.has-web-stories-support.twenty-sixteen
+  > .web-stories-list
+  .web-stories-list__story-content-overlay,
+.has-web-stories-support.twenty-sixteen
+  > .web-stories-list
+  .web-stories-list__archive-link
+  a {
+  color: #fff;
+}
+
+.has-web-stories-support.twenty-sixteen
+  > .web-stories-list
+  .web-stories-list__archive-link
+  a:hover,
+.has-web-stories-support.twenty-sixteen
+  > .web-stories-list
+  .web-stories-list__archive-link
+  a:focus {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+@media screen and (min-width: 44.375em) {
+  .has-web-stories-support.twenty-sixteen > .web-stories-list {
+    padding-top: 33px;
+  }
+
+  .has-web-stories-support.twenty-sixteen > .web-stories-list.has-archive-link {
+    padding-top: 52px;
+    margin-top: 0;
+  }
+}

--- a/assets/src/web-stories-block/css/core-themes/twenty-sixteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-sixteen.css
@@ -1,35 +1,37 @@
-.is-showing-header-stories > .web-stories-list {
+.web-stories-theme-header-section .web-stories-list {
   border-bottom: none;
 }
 
-.is-showing-header-stories > .web-stories-list .web-stories-list__archive-link,
-.is-showing-header-stories
-  > .web-stories-list
+.web-stories-theme-header-section
+  .web-stories-list
+  .web-stories-list__archive-link,
+.web-stories-theme-header-section
+  .web-stories-list
   .web-stories-list__story-content-overlay,
-.is-showing-header-stories
-  > .web-stories-list
+.web-stories-theme-header-section
+  .web-stories-list
   .web-stories-list__archive-link
   a {
   color: #fff;
 }
 
-.is-showing-header-stories
-  > .web-stories-list
+.web-stories-theme-header-section
+  .web-stories-list
   .web-stories-list__archive-link
   a:hover,
-.is-showing-header-stories
-  > .web-stories-list
+.web-stories-theme-header-section
+  .web-stories-list
   .web-stories-list__archive-link
   a:focus {
   color: rgba(255, 255, 255, 0.8);
 }
 
 @media screen and (min-width: 44.375em) {
-  .is-showing-header-stories > .web-stories-list {
+  .web-stories-theme-header-section .web-stories-list {
     padding-top: 33px;
   }
 
-  .is-showing-header-stories > .web-stories-list.has-archive-link {
+  .web-stories-theme-header-section .web-stories-list.has-archive-link {
     padding-top: 52px;
     margin-top: 0;
   }

--- a/assets/src/web-stories-block/css/core-themes/twenty-sixteen.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-sixteen.css
@@ -1,25 +1,23 @@
-.has-web-stories-support.twenty-sixteen > .web-stories-list {
+.is-showing-header-stories > .web-stories-list {
   border-bottom: none;
 }
 
-.has-web-stories-support.twenty-sixteen
-  > .web-stories-list
-  .web-stories-list__archive-link,
-.has-web-stories-support.twenty-sixteen
+.is-showing-header-stories > .web-stories-list .web-stories-list__archive-link,
+.is-showing-header-stories
   > .web-stories-list
   .web-stories-list__story-content-overlay,
-.has-web-stories-support.twenty-sixteen
+.is-showing-header-stories
   > .web-stories-list
   .web-stories-list__archive-link
   a {
   color: #fff;
 }
 
-.has-web-stories-support.twenty-sixteen
+.is-showing-header-stories
   > .web-stories-list
   .web-stories-list__archive-link
   a:hover,
-.has-web-stories-support.twenty-sixteen
+.is-showing-header-stories
   > .web-stories-list
   .web-stories-list__archive-link
   a:focus {
@@ -27,11 +25,11 @@
 }
 
 @media screen and (min-width: 44.375em) {
-  .has-web-stories-support.twenty-sixteen > .web-stories-list {
+  .is-showing-header-stories > .web-stories-list {
     padding-top: 33px;
   }
 
-  .has-web-stories-support.twenty-sixteen > .web-stories-list.has-archive-link {
+  .is-showing-header-stories > .web-stories-list.has-archive-link {
     padding-top: 52px;
     margin-top: 0;
   }

--- a/assets/src/web-stories-block/css/core-themes/twenty-ten.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-ten.css
@@ -1,0 +1,11 @@
+.has-web-stories-support.twenty-ten > .web-stories-list {
+  max-width: 940px;
+  margin: 0 auto;
+  padding-right: 20px;
+  padding-left: 20px;
+  background-color: white;
+}
+
+.has-web-stories-support.twenty-ten #wrapper {
+  margin-top: 0;
+}

--- a/assets/src/web-stories-block/css/core-themes/twenty-ten.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-ten.css
@@ -6,6 +6,6 @@
   background-color: white;
 }
 
-.is-showing-header-stories #wrapper {
+.has-web-stories #wrapper {
   margin-top: 0;
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-ten.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-ten.css
@@ -1,4 +1,4 @@
-.is-showing-header-stories > .web-stories-list {
+.web-stories-theme-header-section .web-stories-list {
   max-width: 940px;
   margin: 0 auto;
   padding-right: 20px;

--- a/assets/src/web-stories-block/css/core-themes/twenty-ten.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-ten.css
@@ -1,4 +1,4 @@
-.has-web-stories-support.twenty-ten > .web-stories-list {
+.is-showing-header-stories > .web-stories-list {
   max-width: 940px;
   margin: 0 auto;
   padding-right: 20px;
@@ -6,6 +6,6 @@
   background-color: white;
 }
 
-.has-web-stories-support.twenty-ten #wrapper {
+.is-showing-header-stories #wrapper {
   margin-top: 0;
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-twelve.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twelve.css
@@ -1,29 +1,29 @@
-.has-web-stories-support.twenty-twelve > .web-stories-list {
+.is-showing-header-stories > .web-stories-list {
   max-width: 68.571428571rem;
   margin: 0 auto;
   padding-right: 1.714285714rem;
   padding-left: 1.714285714rem;
 }
 
-.has-web-stories-support.twenty-twelve > .web-stories-list.has-archive-link {
+.is-showing-header-stories > .web-stories-list.has-archive-link {
   padding-top: 52px;
   background: white;
 }
 
 @media screen and (min-width: 600px) {
-  .has-web-stories-support.twenty-twelve > .web-stories-list {
+  .is-showing-header-stories > .web-stories-list {
     max-width: 68.571428571rem;
     box-shadow: 0 -10px 6px rgb(100 100 100 / 30%);
   }
 }
 
 @media screen and (min-width: 960px) {
-  .has-web-stories-support.twenty-twelve > .web-stories-list {
+  .is-showing-header-stories > .web-stories-list {
     padding-right: 2.857142857rem;
     padding-left: 2.857142857rem;
   }
 
-  .has-web-stories-support.twenty-twelve .site {
+  .is-showing-header-stories .site {
     margin-top: 0;
   }
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-twelve.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twelve.css
@@ -1,0 +1,29 @@
+.has-web-stories-support.twenty-twelve > .web-stories-list {
+  max-width: 68.571428571rem;
+  margin: 0 auto;
+  padding-right: 1.714285714rem;
+  padding-left: 1.714285714rem;
+}
+
+.has-web-stories-support.twenty-twelve > .web-stories-list.has-archive-link {
+  padding-top: 52px;
+  background: white;
+}
+
+@media screen and (min-width: 600px) {
+  .has-web-stories-support.twenty-twelve > .web-stories-list {
+    max-width: 68.571428571rem;
+    box-shadow: 0 -10px 6px rgb(100 100 100 / 30%);
+  }
+}
+
+@media screen and (min-width: 960px) {
+  .has-web-stories-support.twenty-twelve > .web-stories-list {
+    padding-right: 2.857142857rem;
+    padding-left: 2.857142857rem;
+  }
+
+  .has-web-stories-support.twenty-twelve .site {
+    margin-top: 0;
+  }
+}

--- a/assets/src/web-stories-block/css/core-themes/twenty-twelve.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twelve.css
@@ -23,7 +23,7 @@
     padding-left: 2.857142857rem;
   }
 
-  .is-showing-header-stories .site {
+  .has-web-stories .site {
     margin-top: 0;
   }
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-twelve.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twelve.css
@@ -1,24 +1,24 @@
-.is-showing-header-stories > .web-stories-list {
+.web-stories-theme-header-section .web-stories-list {
   max-width: 68.571428571rem;
   margin: 0 auto;
   padding-right: 1.714285714rem;
   padding-left: 1.714285714rem;
 }
 
-.is-showing-header-stories > .web-stories-list.has-archive-link {
+.web-stories-theme-header-section .web-stories-list.has-archive-link {
   padding-top: 52px;
   background: white;
 }
 
 @media screen and (min-width: 600px) {
-  .is-showing-header-stories > .web-stories-list {
+  .web-stories-theme-header-section .web-stories-list {
     max-width: 68.571428571rem;
     box-shadow: 0 -10px 6px rgb(100 100 100 / 30%);
   }
 }
 
 @media screen and (min-width: 960px) {
-  .is-showing-header-stories > .web-stories-list {
+  .web-stories-theme-header-section .web-stories-list {
     padding-right: 2.857142857rem;
     padding-left: 2.857142857rem;
   }

--- a/assets/src/web-stories-block/css/core-themes/twenty-twenty-one.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twenty-one.css
@@ -19,8 +19,7 @@
   }
 
   /* Carousel arrows were visible over primary navigation menu on mobile. */
-  .is-showing-header-stories.primary-navigation-open
-    .web-stories-theme-header-section {
+  .has-web-stories.primary-navigation-open .web-stories-theme-header-section {
     z-index: 0;
   }
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-twenty-one.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twenty-one.css
@@ -1,4 +1,4 @@
-.is-showing-header-stories
+.web-stories-theme-header-section
   .web-stories-list.is-carousel
   .web-stories-list__archive-link {
   font-size: var(--primary-nav--font-size-button);
@@ -7,19 +7,20 @@
 
 @media only screen and (max-width: 481px) {
   /* To ensure that the 'view-all' link has some space from the frame. */
-  .is-showing-header-stories .web-stories-list__inner-wrapper {
+  .web-stories-theme-header-section .web-stories-list__inner-wrapper {
     max-width: var(--responsive--aligndefault-width);
     margin-left: auto;
     margin-right: auto;
   }
 
   /* Fix for menu toggle overlap. */
-  .is-showing-header-stories > .web-stories-list--customizer {
+  .web-stories-theme-header-section .web-stories-list--customizer {
     margin-top: 72px;
   }
 
   /* Carousel arrows were visible over primary navigation menu on mobile. */
-  .is-showing-header-stories.primary-navigation-open > .web-stories-list {
+  .is-showing-header-stories.primary-navigation-open
+    .web-stories-theme-header-section {
     z-index: 0;
   }
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-twenty-one.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twenty-one.css
@@ -1,4 +1,4 @@
-.has-web-stories-support.twenty-twenty-one
+.is-showing-header-stories
   .web-stories-list.is-carousel
   .web-stories-list__archive-link {
   font-size: var(--primary-nav--font-size-button);
@@ -7,20 +7,19 @@
 
 @media only screen and (max-width: 481px) {
   /* To ensure that the 'view-all' link has some space from the frame. */
-  .has-web-stories-support.twenty-twenty-one .web-stories-list__inner-wrapper {
+  .is-showing-header-stories .web-stories-list__inner-wrapper {
     max-width: var(--responsive--aligndefault-width);
     margin-left: auto;
     margin-right: auto;
   }
 
   /* Fix for menu toggle overlap. */
-  .has-web-stories-support.twenty-twenty-one > .web-stories-list--customizer {
+  .is-showing-header-stories > .web-stories-list--customizer {
     margin-top: 72px;
   }
 
   /* Carousel arrows were visible over primary navigation menu on mobile. */
-  .has-web-stories-support.twenty-twenty-one.primary-navigation-open
-    > .web-stories-list {
+  .is-showing-header-stories.primary-navigation-open > .web-stories-list {
     z-index: 0;
   }
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-twenty-one.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twenty-one.css
@@ -1,0 +1,26 @@
+.has-web-stories-support.twenty-twenty-one
+  .web-stories-list.is-carousel
+  .web-stories-list__archive-link {
+  font-size: var(--primary-nav--font-size-button);
+  font-weight: var(--primary-nav--font-weight-button);
+}
+
+@media only screen and (max-width: 481px) {
+  /* To ensure that the 'view-all' link has some space from the frame. */
+  .has-web-stories-support.twenty-twenty-one .web-stories-list__inner-wrapper {
+    max-width: var(--responsive--aligndefault-width);
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  /* Fix for menu toggle overlap. */
+  .has-web-stories-support.twenty-twenty-one > .web-stories-list--customizer {
+    margin-top: 72px;
+  }
+
+  /* Carousel arrows were visible over primary navigation menu on mobile. */
+  .has-web-stories-support.twenty-twenty-one.primary-navigation-open
+    > .web-stories-list {
+    z-index: 0;
+  }
+}

--- a/assets/src/web-stories-block/css/core-themes/twenty-twenty.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twenty.css
@@ -1,4 +1,4 @@
-.is-showing-header-stories > .web-stories-list {
+.web-stories-theme-header-section .web-stories-list {
   margin-top: 0;
   margin-bottom: 0;
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-twenty.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twenty.css
@@ -1,4 +1,4 @@
-.has-web-stories-support.twenty-twenty > .web-stories-list {
+.is-showing-header-stories > .web-stories-list {
   margin-top: 0;
   margin-bottom: 0;
 }

--- a/assets/src/web-stories-block/css/core-themes/twenty-twenty.css
+++ b/assets/src/web-stories-block/css/core-themes/twenty-twenty.css
@@ -1,0 +1,4 @@
+.has-web-stories-support.twenty-twenty > .web-stories-list {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/assets/src/web-stories-block/css/views/carousel.css
+++ b/assets/src/web-stories-block/css/views/carousel.css
@@ -9,12 +9,12 @@
 
 .web-stories-list.is-carousel.has-archive-link {
   position: relative;
-  margin-top: 32px;
+  padding-top: 42px;
 }
 
 .web-stories-list.is-carousel .web-stories-list__archive-link {
   position: absolute;
-  right: 0;
+  right: 10px;
   top: -32px;
 }
 

--- a/assets/src/web-stories-block/css/views/circles.css
+++ b/assets/src/web-stories-block/css/views/circles.css
@@ -4,7 +4,7 @@
   overflow-y: hidden;
 }
 
-body > .web-stories-list.is-view-type-circles {
+body > .web-stories-list {
   border-bottom: 1px solid #ccc;
   padding: 12px 0;
 }

--- a/assets/src/web-stories-block/css/views/circles.css
+++ b/assets/src/web-stories-block/css/views/circles.css
@@ -4,7 +4,7 @@
   overflow-y: hidden;
 }
 
-body > .web-stories-list {
+.web-stories-theme-header-section .web-stories-list {
   border-bottom: 1px solid #ccc;
   padding: 12px 0;
 }
@@ -40,6 +40,11 @@ body > .web-stories-list {
 .web-stories-list.is-view-type-circles .web-stories-list__story-poster::after,
 .web-stories-list.is-view-type-circles .web-stories-list__story-poster::before {
   display: none;
+}
+
+.web-stories-list.is-view-type-circles
+  .web-stories-list__story-content-overlay {
+  padding-bottom: 0;
 }
 
 .web-stories-list.is-view-type-circles .story-content-overlay__title {

--- a/assets/src/web-stories-block/css/views/circles.css
+++ b/assets/src/web-stories-block/css/views/circles.css
@@ -42,11 +42,6 @@ body > .web-stories-list.is-view-type-circles {
   display: none;
 }
 
-.web-stories-list.is-view-type-circles
-  .web-stories-list__story-content-overlay {
-  padding-bottom: 0;
-}
-
 .web-stories-list.is-view-type-circles .story-content-overlay__title {
   font-size: var(--ws-font-size-circle-title);
 }

--- a/includes/Integrations/Core_Themes_Support.php
+++ b/includes/Integrations/Core_Themes_Support.php
@@ -27,11 +27,20 @@
 namespace Google\Web_Stories\Integrations;
 
 use Google\Web_Stories\Customizer;
+use Google\Web_Stories\Traits\Assets;
 
 /**
  * Class Core_Themes_Support.
  */
 class Core_Themes_Support {
+	use Assets;
+
+	/**
+	 * Style handle for the core themes styles.
+	 *
+	 * @var string
+	 */
+	const STYLE_HANDLE = 'web-stories-core-themes-styles';
 
 	/**
 	 * Default array of core themes to add support to.
@@ -51,6 +60,17 @@ class Core_Themes_Support {
 		'twentyeleven',
 		'twentyten',
 	];
+
+	/**
+	 * Register Core theme styles.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return void
+	 */
+	public function assets() {
+		$this->register_style( self::STYLE_HANDLE );
+	}
 
 	/**
 	 * Adds theme support for Web Stories.
@@ -77,7 +97,25 @@ class Core_Themes_Support {
 	 */
 	public function embed_web_stories() {
 		$customizer = new Customizer();
+		$this->enqueue_style( self::STYLE_HANDLE );
 		echo $customizer->render_stories(); // phpcs:ignore -- WordPress.Security.EscapeOutput.OutputNotEscaped - Escaped web stories HTML.
+	}
+
+	/**
+	 * Adds current theme class on 'body' tag, if it is one of
+	 * supported core themes.
+	 *
+	 * @since 1.3.0
+	 * @param array $classes Array of body classes.
+	 *
+	 * @return array Updated array of classes.
+	 */
+	public function add_core_theme_classes( $classes ) {
+
+		$classes[] = 'has-web-stories-support';
+		$classes[] = sanitize_title( wp_get_theme() );
+
+		return $classes;
 	}
 
 	/**
@@ -94,6 +132,10 @@ class Core_Themes_Support {
 		}
 
 		$this->extend_theme_support();
+
+		add_action( 'wp_enqueue_scripts', [ $this, 'assets' ] );
 		add_action( 'wp_body_open', [ $this, 'embed_web_stories' ] );
+
+		add_filter( 'body_class', [ $this, 'add_core_theme_classes' ] );
 	}
 }

--- a/includes/Integrations/Core_Themes_Support.php
+++ b/includes/Integrations/Core_Themes_Support.php
@@ -27,6 +27,7 @@
 namespace Google\Web_Stories\Integrations;
 
 use Google\Web_Stories\Customizer;
+use Google\Web_Stories\Stories_Renderer\Renderer;
 use Google\Web_Stories\Traits\Assets;
 
 /**
@@ -36,11 +37,18 @@ class Core_Themes_Support {
 	use Assets;
 
 	/**
-	 * Style handle for the core themes styles.
+	 * Style handle for current theme.
 	 *
 	 * @var string
 	 */
-	const STYLE_HANDLE = 'web-stories-core-themes-styles';
+	protected $style_handle = '';
+
+	/**
+	 * Is customizer stories showing.
+	 *
+	 * @var boolean
+	 */
+	protected $showing_customizer_stories = null;
 
 	/**
 	 * Default array of core themes to add support to.
@@ -69,7 +77,7 @@ class Core_Themes_Support {
 	 * @return void
 	 */
 	public function assets() {
-		$this->register_style( self::STYLE_HANDLE );
+		$this->register_style( $this->style_handle, [ Renderer::STYLE_HANDLE ] );
 	}
 
 	/**
@@ -97,13 +105,12 @@ class Core_Themes_Support {
 	 */
 	public function embed_web_stories() {
 		$customizer = new Customizer();
-		$this->enqueue_style( self::STYLE_HANDLE );
+		$this->enqueue_style( $this->style_handle );
 		echo $customizer->render_stories(); // phpcs:ignore -- WordPress.Security.EscapeOutput.OutputNotEscaped - Escaped web stories HTML.
 	}
 
 	/**
-	 * Adds current theme class on 'body' tag, if it is one of
-	 * supported core themes.
+	 * Add a class if it is one of supported core themes.
 	 *
 	 * @since 1.3.0
 	 * @param array $classes Array of body classes.
@@ -113,7 +120,10 @@ class Core_Themes_Support {
 	public function add_core_theme_classes( $classes ) {
 
 		$classes[] = 'has-web-stories-support';
-		$classes[] = sanitize_title( wp_get_theme() );
+
+		if ( $this->showing_customizer_stories ) {
+			$classes[] = 'is-showing-header-stories';
+		}
 
 		return $classes;
 	}
@@ -131,11 +141,18 @@ class Core_Themes_Support {
 			return;
 		}
 
+		$this->style_handle = 'core-themes/' . sanitize_title( wp_get_theme() );
 		$this->extend_theme_support();
 
-		add_action( 'wp_enqueue_scripts', [ $this, 'assets' ] );
-		add_action( 'wp_body_open', [ $this, 'embed_web_stories' ] );
+		$options                          = get_option( Customizer::STORY_OPTION );
+		$this->showing_customizer_stories = ! empty( $options['show_stories'] );
 
 		add_filter( 'body_class', [ $this, 'add_core_theme_classes' ] );
+
+		// Load theme specific styles and render function only if selected to show stories.
+		if ( $this->showing_customizer_stories ) {
+			add_action( 'wp_enqueue_scripts', [ $this, 'assets' ] );
+			add_action( 'wp_body_open', [ $this, 'embed_web_stories' ] );
+		}
 	}
 }

--- a/includes/Integrations/Core_Themes_Support.php
+++ b/includes/Integrations/Core_Themes_Support.php
@@ -63,17 +63,6 @@ class Core_Themes_Support {
 	];
 
 	/**
-	 * Register Core theme styles.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @return void
-	 */
-	public function assets() {
-		$this->register_style( $this->style_handle, [ Renderer::STYLE_HANDLE ] );
-	}
-
-	/**
 	 * Adds theme support for Web Stories.
 	 *
 	 * This will enable add_theme_support with predefined
@@ -98,7 +87,7 @@ class Core_Themes_Support {
 	 */
 	public function embed_web_stories() {
 		$customizer = new Customizer();
-		$this->enqueue_style( $this->style_handle );
+		$this->enqueue_style( $this->style_handle, [ Renderer::STYLE_HANDLE ] );
 		?>
 		<div class="web-stories-theme-header-section">
 			<?php echo $customizer->render_stories(); // phpcs:ignore -- WordPress.Security.EscapeOutput.OutputNotEscaped - Escaped web stories HTML. ?>
@@ -144,7 +133,6 @@ class Core_Themes_Support {
 			return;
 		}
 
-		add_action( 'wp_enqueue_scripts', [ $this, 'assets' ] );
 		add_filter( 'body_class', [ $this, 'add_core_theme_classes' ] );
 		add_action( 'wp_body_open', [ $this, 'embed_web_stories' ] );
 	}

--- a/includes/Integrations/Core_Themes_Support.php
+++ b/includes/Integrations/Core_Themes_Support.php
@@ -44,13 +44,6 @@ class Core_Themes_Support {
 	protected $style_handle = '';
 
 	/**
-	 * Is customizer stories showing.
-	 *
-	 * @var boolean
-	 */
-	protected $showing_customizer_stories = null;
-
-	/**
 	 * Default array of core themes to add support to.
 	 *
 	 * @var array
@@ -123,9 +116,7 @@ class Core_Themes_Support {
 	 */
 	public function add_core_theme_classes( $classes ) {
 
-		if ( $this->showing_customizer_stories ) {
-			$classes[] = 'is-showing-header-stories';
-		}
+		$classes[] = 'has-web-stories';
 
 		return $classes;
 	}
@@ -146,11 +137,10 @@ class Core_Themes_Support {
 		$this->style_handle = 'web-stories-theme-style-' . get_stylesheet();
 		$this->extend_theme_support();
 
-		$options                          = get_option( Customizer::STORY_OPTION );
-		$this->showing_customizer_stories = ! empty( $options['show_stories'] );
+		$options = get_option( Customizer::STORY_OPTION );
 
 		// Load theme specific styles and render function only if selected to show stories.
-		if ( ! $this->showing_customizer_stories ) {
+		if ( empty( $options['show_stories'] ) ) {
 			return;
 		}
 

--- a/includes/Integrations/Core_Themes_Support.php
+++ b/includes/Integrations/Core_Themes_Support.php
@@ -37,13 +37,6 @@ class Core_Themes_Support {
 	use Assets;
 
 	/**
-	 * Style handle for current theme.
-	 *
-	 * @var string
-	 */
-	protected $style_handle = '';
-
-	/**
 	 * Default array of core themes to add support to.
 	 *
 	 * @var array
@@ -87,7 +80,7 @@ class Core_Themes_Support {
 	 */
 	public function embed_web_stories() {
 		$customizer = new Customizer();
-		$this->enqueue_style( $this->style_handle, [ Renderer::STYLE_HANDLE ] );
+		$this->enqueue_style( 'web-stories-theme-style-' . get_stylesheet(), [ Renderer::STYLE_HANDLE ] );
 		?>
 		<div class="web-stories-theme-header-section">
 			<?php echo $customizer->render_stories(); // phpcs:ignore -- WordPress.Security.EscapeOutput.OutputNotEscaped - Escaped web stories HTML. ?>
@@ -123,7 +116,6 @@ class Core_Themes_Support {
 			return;
 		}
 
-		$this->style_handle = 'web-stories-theme-style-' . get_stylesheet();
 		$this->extend_theme_support();
 
 		$options = get_option( Customizer::STORY_OPTION );

--- a/includes/Integrations/Core_Themes_Support.php
+++ b/includes/Integrations/Core_Themes_Support.php
@@ -106,7 +106,11 @@ class Core_Themes_Support {
 	public function embed_web_stories() {
 		$customizer = new Customizer();
 		$this->enqueue_style( $this->style_handle );
-		echo $customizer->render_stories(); // phpcs:ignore -- WordPress.Security.EscapeOutput.OutputNotEscaped - Escaped web stories HTML.
+		?>
+		<div class="web-stories-theme-header-section">
+			<?php echo $customizer->render_stories(); // phpcs:ignore -- WordPress.Security.EscapeOutput.OutputNotEscaped - Escaped web stories HTML. ?>
+		</div>
+		<?php
 	}
 
 	/**
@@ -118,8 +122,6 @@ class Core_Themes_Support {
 	 * @return array Updated array of classes.
 	 */
 	public function add_core_theme_classes( $classes ) {
-
-		$classes[] = 'has-web-stories-support';
 
 		if ( $this->showing_customizer_stories ) {
 			$classes[] = 'is-showing-header-stories';
@@ -141,18 +143,19 @@ class Core_Themes_Support {
 			return;
 		}
 
-		$this->style_handle = 'core-themes/' . sanitize_title( wp_get_theme() );
+		$this->style_handle = 'web-stories-theme-style-' . get_stylesheet();
 		$this->extend_theme_support();
 
 		$options                          = get_option( Customizer::STORY_OPTION );
 		$this->showing_customizer_stories = ! empty( $options['show_stories'] );
 
-		add_filter( 'body_class', [ $this, 'add_core_theme_classes' ] );
-
 		// Load theme specific styles and render function only if selected to show stories.
-		if ( $this->showing_customizer_stories ) {
-			add_action( 'wp_enqueue_scripts', [ $this, 'assets' ] );
-			add_action( 'wp_body_open', [ $this, 'embed_web_stories' ] );
+		if ( ! $this->showing_customizer_stories ) {
+			return;
 		}
+
+		add_action( 'wp_enqueue_scripts', [ $this, 'assets' ] );
+		add_filter( 'body_class', [ $this, 'add_core_theme_classes' ] );
+		add_action( 'wp_body_open', [ $this, 'embed_web_stories' ] );
 	}
 }

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-testing-library": "^3.10.1",
+    "glob": "^7.1.6",
     "got": "^11.8.1",
     "husky": "^4.3.7",
     "jasmine-core": "^3.6.0",

--- a/tests/phpunit/tests/Integrations/Core_Themes_Support.php
+++ b/tests/phpunit/tests/Integrations/Core_Themes_Support.php
@@ -76,6 +76,8 @@ class Core_Themes_Support extends \WP_UnitTestCase {
 	public function test_init() {
 		$this->stub->init();
 
+		$this->assertEquals( 10, has_action( 'wp_enqueue_scripts', [ $this->stub, 'assets' ] ) );
+		$this->assertEquals( 10, has_action( 'body_class', [ $this->stub, 'add_core_theme_classes' ] ) );
 		$this->assertEquals( 10, has_action( 'wp_body_open', [ $this->stub, 'embed_web_stories' ] ) );
 	}
 

--- a/tests/phpunit/tests/Integrations/Core_Themes_Support.php
+++ b/tests/phpunit/tests/Integrations/Core_Themes_Support.php
@@ -17,6 +17,7 @@
 
 namespace Google\Web_Stories\Tests\Integrations;
 
+use Google\Web_Stories\Customizer;
 use Google\Web_Stories\Tests\Private_Access;
 
 /**
@@ -47,6 +48,7 @@ class Core_Themes_Support extends \WP_UnitTestCase {
 
 		// Set stylesheet from one of the supported themes.
 		update_option( 'stylesheet', 'twentytwentyone' );
+		update_option( Customizer::STORY_OPTION, [ 'show_stories' => true ] );
 		$this->stub = new \Google\Web_Stories\Integrations\Core_Themes_Support();
 	}
 
@@ -77,7 +79,7 @@ class Core_Themes_Support extends \WP_UnitTestCase {
 		$this->stub->init();
 
 		$this->assertEquals( 10, has_action( 'wp_enqueue_scripts', [ $this->stub, 'assets' ] ) );
-		$this->assertEquals( 10, has_action( 'body_class', [ $this->stub, 'add_core_theme_classes' ] ) );
+		$this->assertEquals( 10, has_filter( 'body_class', [ $this->stub, 'add_core_theme_classes' ] ) );
 		$this->assertEquals( 10, has_action( 'wp_body_open', [ $this->stub, 'embed_web_stories' ] ) );
 	}
 

--- a/tests/phpunit/tests/Integrations/Core_Themes_Support.php
+++ b/tests/phpunit/tests/Integrations/Core_Themes_Support.php
@@ -78,7 +78,6 @@ class Core_Themes_Support extends \WP_UnitTestCase {
 	public function test_init() {
 		$this->stub->init();
 
-		$this->assertEquals( 10, has_action( 'wp_enqueue_scripts', [ $this->stub, 'assets' ] ) );
 		$this->assertEquals( 10, has_filter( 'body_class', [ $this->stub, 'add_core_theme_classes' ] ) );
 		$this->assertEquals( 10, has_action( 'wp_body_open', [ $this->stub, 'embed_web_stories' ] ) );
 	}
@@ -141,5 +140,19 @@ class Core_Themes_Support extends \WP_UnitTestCase {
 		$this->stub->init();
 
 		$this->assertFalse( get_theme_support( 'web-stories' ) );
+	}
+
+	/**
+	 *
+	 * @covers ::embed_web_stories
+	 */
+	public function embed_web_stories() {
+		ob_start();
+		$this->stub->embed_web_stories();
+
+		$actual = ob_get_clean();
+
+		$this->assertTrue( wp_script_is( 'web-stories-theme-style-twentytwentyone' ) );
+		$this->assertContains( 'web-stories-theme-header-section', $actual );
 	}
 }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -226,12 +226,11 @@ const coreThemesBlockStylesPaths = glob.sync(
 
 // Build entry object for the Core Themes Styles.
 const coreThemeBlockStyles = coreThemesBlockStylesPaths.reduce((acc, curr) => {
-  const length = curr.indexOf('.css') - curr.indexOf('core-themes/');
-  const fileName = curr.substr(curr.indexOf('core-themes/'), length);
+  const fileName = path.parse(curr).name.replace('-', '');
 
   return {
     ...acc,
-    [fileName]: curr,
+    [`web-stories-theme-style-${fileName}`]: curr,
   };
 }, {});
 

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -18,6 +18,7 @@
  * External dependencies
  */
 const path = require('path');
+const glob = require('glob');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
@@ -218,6 +219,22 @@ const webStoriesScripts = {
   ].filter(Boolean),
 };
 
+// Collect all core themes style sheet paths.
+const coreThemesBlockStylesPaths = glob.sync(
+  './assets/src/web-stories-block/css/core-themes/*.css'
+);
+
+// Build entry object for the Core Themes Styles.
+const coreThemeBlockStyles = coreThemesBlockStylesPaths.reduce((acc, curr) => {
+  const length = curr.indexOf('.css') - curr.indexOf('core-themes/');
+  const fileName = curr.substr(curr.indexOf('core-themes/'), length);
+
+  return {
+    ...acc,
+    [fileName]: curr,
+  };
+}, {});
+
 const webStoriesBlock = {
   ...sharedConfig,
   entry: {
@@ -226,8 +243,7 @@ const webStoriesBlock = {
       './assets/src/web-stories-block/block/edit.css',
     ],
     'web-stories-list-styles': './assets/src/web-stories-block/css/style.css',
-    'web-stories-core-themes-styles':
-      './assets/src/web-stories-block/css/core-themes.css',
+    ...coreThemeBlockStyles,
   },
   plugins: [
     ...sharedConfig.plugins,

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -226,7 +226,7 @@ const coreThemesBlockStylesPaths = glob.sync(
 
 // Build entry object for the Core Themes Styles.
 const coreThemeBlockStyles = coreThemesBlockStylesPaths.reduce((acc, curr) => {
-  const fileName = path.parse(curr).name.replace('-', '');
+  const fileName = path.parse(curr).name.replace(/-/g, '');
 
   return {
     ...acc,

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -226,6 +226,8 @@ const webStoriesBlock = {
       './assets/src/web-stories-block/block/edit.css',
     ],
     'web-stories-list-styles': './assets/src/web-stories-block/css/style.css',
+    'web-stories-core-themes-styles':
+      './assets/src/web-stories-block/css/core-themes.css',
   },
   plugins: [
     ...sharedConfig.plugins,


### PR DESCRIPTION
## Context

Web Stories by default adds support for core themes from `twenty-ten` through `twenty-twenty-one`. This PR adds basic styles for Web Stories to display properly when enabled from customizer.

## Relevant Technical Choices

- While we are managing the styles for each core theme in a separate file, however due to small size of the built file we are using single built file to load the style.

## User-facing changes

- User will see Web Stories, if enabled, at the top of the page.

## Testing Instructions

- Enable Web Stories from the customizer and test the rendered page for each of the core themes supported.
- May be use [Theme Switcha](https://wordpress.org/plugins/theme-switcha/) plugin to quickly switch theme on frontend to test.
