### PR TITLE
Stories block: Enable glider carousel for the editor screen.

### DIFF
--- a/assets/src/web-stories-block/block/components/storiesInspectorControls.js
+++ b/assets/src/web-stories-block/block/components/storiesInspectorControls.js
@@ -30,22 +30,15 @@ import {
   RangeControl,
   SelectControl,
   ToggleControl,
-  Notice,
 } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
-import {
-  createInterpolateElement,
-  useEffect,
-  useRef,
-} from '@wordpress/element';
-import { select } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { useConfig } from '../config';
 import {
-  CAROUSEL_VIEW_TYPE,
   CIRCLES_VIEW_TYPE,
   GRID_VIEW_TYPE,
   ORDER_BY_OPTIONS,
@@ -55,10 +48,6 @@ import AuthorSelection from './authorSelection';
 const StyledTextArea = styled(TextControl)`
   width: 80%;
   margin-left: auto;
-`;
-
-const StyledNotice = styled(Notice)`
-  margin: 0 0 20px 0;
 `;
 
 const StyledToggle = styled(ToggleControl)`
@@ -167,18 +156,6 @@ const StoriesInspectorControls = (props) => {
     </a>
   );
 
-  const previewLink = select('core/editor').getEditedPostPreviewLink();
-  const carouselMessage = createInterpolateElement(
-    __(
-      `<b>Note:</b> Carousel functionality will not work in Editor. <a>Preview</a> post to see it in action.`,
-      'web-stories'
-    ),
-    {
-      b: <b />,
-      a: <a href={previewLink} target="__blank" rel="noreferrer" />, // eslint-disable-line jsx-a11y/anchor-has-content
-    }
-  );
-
   const handleToggleControl = (field) => {
     setAttributes({
       fieldState: {
@@ -194,17 +171,6 @@ const StoriesInspectorControls = (props) => {
         className="web-stories-settings"
         title={__('Story settings', 'web-stories')}
       >
-        {(CAROUSEL_VIEW_TYPE === viewType ||
-          CIRCLES_VIEW_TYPE === viewType) && (
-          <StyledNotice
-            className="web-stories-carousel-message"
-            isDismissible={false}
-            status="warning"
-          >
-            {carouselMessage}
-          </StyledNotice>
-        )}
-
         {fieldStates[viewType] &&
           Object.entries(fieldStates[viewType]).map(([field, fieldObj]) => {
             const { label, readonly } = fieldObj;

--- a/assets/src/web-stories-block/block/components/storiesPreview.js
+++ b/assets/src/web-stories-block/block/components/storiesPreview.js
@@ -19,6 +19,8 @@
  */
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Glider from 'glider-js';
+import 'glider-js/glider.css';
 
 /**
  * WordPress dependencies
@@ -97,13 +99,13 @@ function StoriesPreview(props) {
     });
 
   useEffect(() => {
-    if (carouselContainer.current) {
+    if (carouselContainer.current && carouselItem.current) {
       const itemStyle = window.getComputedStyle(carouselItem.current);
       const itemWidth =
         parseFloat(itemStyle.width) +
         (parseFloat(itemStyle.marginLeft) + parseFloat(itemStyle.marginRight));
 
-      /* eslint-disable-next-line no-new, no-undef */
+      /* eslint-disable-next-line no-new */
       new Glider(carouselContainer.current, {
         slidesToShow: 'auto',
         slidesToScroll: 'auto',

--- a/assets/src/web-stories-block/block/components/storiesPreview.js
+++ b/assets/src/web-stories-block/block/components/storiesPreview.js
@@ -21,6 +21,13 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { withInstanceId } from '@wordpress/compose';
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { useConfig } from '../config';
@@ -36,9 +43,15 @@ function StoriesPreview(props) {
     attributes: { align, viewType, sizeOfCircles, fieldState, numOfColumns },
     viewAllLabel,
     stories,
+    instanceId,
   } = props;
 
   const { archiveURL } = useConfig();
+
+  const carouselContainer = useRef(null);
+  const carouselNext = useRef(null);
+  const carouselPrev = useRef(null);
+  const carouselItem = useRef(null);
 
   const blockClasses = classNames(
     {
@@ -53,6 +66,58 @@ function StoriesPreview(props) {
     'web-stories-list'
   );
 
+  const wrapperClasses = classNames(
+    {
+      [`carousel-${instanceId}`]:
+        CIRCLES_VIEW_TYPE === viewType || CAROUSEL_VIEW_TYPE === viewType,
+    },
+    'web-stories-list__inner-wrapper'
+  );
+
+  const storiesLoop = () =>
+    stories.map((story) => {
+      return (
+        <StoryCard
+          key={story.id}
+          url={story.link}
+          title={story.title.rendered}
+          excerpt={story.excerpt.rendered ? story.excerpt.rendered : ''}
+          date={story.date_gmt}
+          author={story._embedded.author[0].name}
+          poster={story.featured_media_url}
+          imageOnRight={fieldState['show_image_align']}
+          isShowingAuthor={fieldState['show_author']}
+          isShowingDate={fieldState['show_date']}
+          isShowingTitle={fieldState['show_title']}
+          isShowingExcerpt={fieldState['show_excerpt']}
+          sizeOfCircles={sizeOfCircles}
+          itemRef={carouselItem}
+        />
+      );
+    });
+
+  useEffect(() => {
+    if (carouselContainer.current) {
+      const itemStyle = window.getComputedStyle(carouselItem.current);
+      const itemWidth =
+        parseFloat(itemStyle.width) +
+        (parseFloat(itemStyle.marginLeft) + parseFloat(itemStyle.marginRight));
+
+      /* eslint-disable-next-line no-new, no-undef */
+      new Glider(carouselContainer.current, {
+        slidesToShow: 'auto',
+        slidesToScroll: 'auto',
+        itemWidth,
+        duration: 0.25,
+        scrollLock: true,
+        arrows: {
+          prev: carouselPrev.current,
+          next: carouselNext.current,
+        },
+      });
+    }
+  });
+
   return (
     <div
       className={blockClasses}
@@ -63,26 +128,30 @@ function StoriesPreview(props) {
             : undefined,
       }}
     >
-      <div className="web-stories-list__inner-wrapper">
-        {stories.map((story) => {
-          return (
-            <StoryCard
-              key={story.id}
-              url={story.link}
-              title={story.title.rendered}
-              excerpt={story.excerpt.rendered ? story.excerpt.rendered : ''}
-              date={story.date_gmt}
-              author={story._embedded.author[0].name}
-              poster={story.featured_media_url}
-              imageOnRight={fieldState['show_image_align']}
-              isShowingAuthor={fieldState['show_author']}
-              isShowingDate={fieldState['show_date']}
-              isShowingTitle={fieldState['show_title']}
-              isShowingExcerpt={fieldState['show_excerpt']}
-              sizeOfCircles={sizeOfCircles}
+      <div className={wrapperClasses}>
+        {CIRCLES_VIEW_TYPE === viewType || CAROUSEL_VIEW_TYPE === viewType ? (
+          <>
+            <div
+              className="web-stories-list__carousel"
+              data-id={`carousel-${instanceId}`}
+              ref={carouselContainer}
+            >
+              {storiesLoop()}
+            </div>
+            <div
+              aria-label={__('Previous', 'web-stories')}
+              className="glider-prev"
+              ref={carouselPrev}
             />
-          );
-        })}
+            <div
+              aria-label={__('Next', 'web-stories')}
+              className="glider-next"
+              ref={carouselNext}
+            />
+          </>
+        ) : (
+          <>{storiesLoop()}</>
+        )}
       </div>
       {fieldState['show_archive_link'] && (
         <div className="web-stories-list__archive-link">
@@ -105,6 +174,7 @@ StoriesPreview.propTypes = {
   }),
   stories: PropTypes.array,
   viewAllLabel: PropTypes.string,
+  instanceId: PropTypes.number,
 };
 
-export default StoriesPreview;
+export default withInstanceId(StoriesPreview);

--- a/assets/src/web-stories-block/block/components/storyCard.js
+++ b/assets/src/web-stories-block/block/components/storyCard.js
@@ -38,6 +38,7 @@ function StoryCard({
   isShowingTitle,
   isShowingExcerpt,
   imageOnRight,
+  itemRef,
 }) {
   const singleStoryClasses = classNames('web-stories-list__story', {
     [`image-align-right`]: imageOnRight,
@@ -48,7 +49,7 @@ function StoryCard({
   const dateFormat = __experimentalGetSettings().formats.date;
 
   return (
-    <div className={singleStoryClasses}>
+    <div className={singleStoryClasses} ref={itemRef}>
       <div className="web-stories-list__story-poster">
         <img src={poster} alt={title} />
       </div>
@@ -100,6 +101,7 @@ StoryCard.propTypes = {
   isShowingTitle: PropTypes.bool,
   isShowingExcerpt: PropTypes.bool,
   imageOnRight: PropTypes.bool,
+  itemRef: PropTypes.object,
 };
 
 export default StoryCard;


### PR DESCRIPTION
## Context

Web Stories block uses 'glider.js' for the carousel view, which is only working on the front end of the site. For better user experience we needed it to create similar carousels on the editor as well.

## Summary

This PR adds basic support for supporting carousels in the editor.

## To-do

- RTL support in editor.

## User-facing changes

Before:

https://user-images.githubusercontent.com/6906779/108751066-c7da8400-7567-11eb-83ac-f8edef907bdc.mov

Now:

https://user-images.githubusercontent.com/6906779/108751102-d163ec00-7567-11eb-8042-d8e6bf821423.mov

