### PR TITLE
Carousel layout was breaking in editor when try to reduce the number of stories.

### DIFF
--- a/assets/src/web-stories-block/block/components/storiesPreview.js
+++ b/assets/src/web-stories-block/block/components/storiesPreview.js
@@ -26,7 +26,6 @@ import 'glider-js/glider.css';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withInstanceId } from '@wordpress/compose';
 import { useEffect, useRef } from '@wordpress/element';
 
 /**
@@ -45,7 +44,6 @@ function StoriesPreview(props) {
     attributes: { align, viewType, sizeOfCircles, fieldState, numOfColumns },
     viewAllLabel,
     stories,
-    instanceId,
   } = props;
 
   const { archiveURL } = useConfig();
@@ -53,7 +51,6 @@ function StoriesPreview(props) {
   const carouselContainer = useRef(null);
   const carouselNext = useRef(null);
   const carouselPrev = useRef(null);
-  const carouselItem = useRef(null);
 
   const blockClasses = classNames(
     {
@@ -66,14 +63,6 @@ function StoriesPreview(props) {
       [`align${align}`]: align,
     },
     'web-stories-list'
-  );
-
-  const wrapperClasses = classNames(
-    {
-      [`carousel-${instanceId}`]:
-        CIRCLES_VIEW_TYPE === viewType || CAROUSEL_VIEW_TYPE === viewType,
-    },
-    'web-stories-list__inner-wrapper'
   );
 
   const storiesLoop = () =>
@@ -93,14 +82,21 @@ function StoriesPreview(props) {
           isShowingTitle={fieldState['show_title']}
           isShowingExcerpt={fieldState['show_excerpt']}
           sizeOfCircles={sizeOfCircles}
-          itemRef={carouselItem}
         />
       );
     });
 
   useEffect(() => {
-    if (carouselContainer.current && carouselItem.current) {
-      const itemStyle = window.getComputedStyle(carouselItem.current);
+    if (carouselContainer.current) {
+      const storyItem = carouselContainer.current.querySelector(
+        '.web-stories-list__story'
+      );
+
+      if (!storyItem) {
+        return;
+      }
+
+      const itemStyle = window.getComputedStyle(storyItem);
       const itemWidth =
         parseFloat(itemStyle.width) +
         (parseFloat(itemStyle.marginLeft) + parseFloat(itemStyle.marginRight));
@@ -111,6 +107,7 @@ function StoriesPreview(props) {
         slidesToScroll: 'auto',
         itemWidth,
         duration: 0.25,
+        skipTrack: true,
         scrollLock: true,
         arrows: {
           prev: carouselPrev.current,
@@ -130,15 +127,11 @@ function StoriesPreview(props) {
             : undefined,
       }}
     >
-      <div className={wrapperClasses}>
+      <div className="web-stories-list__inner-wrapper">
         {CIRCLES_VIEW_TYPE === viewType || CAROUSEL_VIEW_TYPE === viewType ? (
           <>
-            <div
-              className="web-stories-list__carousel"
-              data-id={`carousel-${instanceId}`}
-              ref={carouselContainer}
-            >
-              {storiesLoop()}
+            <div className="web-stories-list__carousel" ref={carouselContainer}>
+              <div className="glider-track">{storiesLoop()}</div>
             </div>
             <div
               aria-label={__('Previous', 'web-stories')}
@@ -176,7 +169,6 @@ StoriesPreview.propTypes = {
   }),
   stories: PropTypes.array,
   viewAllLabel: PropTypes.string,
-  instanceId: PropTypes.number,
 };
 
-export default withInstanceId(StoriesPreview);
+export default StoriesPreview;

--- a/assets/src/web-stories-block/block/components/storyCard.js
+++ b/assets/src/web-stories-block/block/components/storyCard.js
@@ -38,7 +38,6 @@ function StoryCard({
   isShowingTitle,
   isShowingExcerpt,
   imageOnRight,
-  itemRef,
 }) {
   const singleStoryClasses = classNames('web-stories-list__story', {
     [`image-align-right`]: imageOnRight,
@@ -49,7 +48,7 @@ function StoryCard({
   const dateFormat = __experimentalGetSettings().formats.date;
 
   return (
-    <div className={singleStoryClasses} ref={itemRef}>
+    <div className={singleStoryClasses}>
       <div className="web-stories-list__story-poster">
         <img src={poster} alt={title} />
       </div>
@@ -101,7 +100,6 @@ StoryCard.propTypes = {
   isShowingTitle: PropTypes.bool,
   isShowingExcerpt: PropTypes.bool,
   imageOnRight: PropTypes.bool,
-  itemRef: PropTypes.object,
 };
 
 export default StoryCard;


### PR DESCRIPTION
## Context

In editor when user tries to reduce the number of stories to show, in any carousel view the block is breaking with error.

## Summary

This PR fixes the issue where the Web Stories block was breaking with following error,
> NotFoundError: The node to be removed is not a child of this node.
when user reduces the number of stories to show.

Also, This PR tries to simplify the structure by removing refs that were not absolutely needed.

## Relevant Technical Choices

- `Glider.js` dynamically adds an element `.glider-track` to wrap the slide elements when `skipTrack` argument is set to `false` ( default ). So with this every-time we increase the number of stories it just adds it to the dynamically created track. But on reducing the number of stories react tries to remove extra story elements but since '.glider-track' is not present it throws this error. `The node to be removed is not a child of this node.`.

- [Solution] Set the `skipTrack` to `true` and add an element `div.glider-track` that wraps your slide elements. This ensures that `.glider-track` will be available all the time.
