### PR TITLE
Fix: View type support

### DIFF
--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -423,7 +423,7 @@ class Customizer {
 			return $view_type_choices;
 		}
 
-		return array_intersect_key( $view_type, $view_type_choices );
+		return array_intersect_key( $view_type_choices, array_fill_keys( $view_type, true ) );
 	}
 
 	/**


### PR DESCRIPTION
### Context

View type support is added by specifying keys, but those are present in values part of the array, because of which there is no intersection happening which doesn't add intended view type support.

### Changes added

Perform the intersection by making the view type keys available via `array_fill_keys`